### PR TITLE
feature: first pass with host wrapped cells projected into datagrid rows.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "clr-all",
-    "version": "0.11.7-patch.1",
+    "version": "0.11.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -10,10 +10,10 @@
             "integrity": "sha512-BAYCVZ10ro6mgZQDZiNiVbX8ppygw4q7z/stpwG8WjMswgMRIcxsxYoC1VFuWcUPAf4UyfTIav6e8UZWA5+xnQ==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "source-map": "0.5.7",
-                "typescript": "2.6.2",
-                "webpack-sources": "1.1.0"
+                "loader-utils": "^1.1.0",
+                "source-map": "^0.5.6",
+                "typescript": "~2.6.2",
+                "webpack-sources": "^1.0.1"
             },
             "dependencies": {
                 "source-map": {
@@ -36,7 +36,7 @@
             "integrity": "sha512-zxrNtTiv60liye/GGeRMnnGgLgAWoqlMTfPLMW0D1qJ4bbrPHtme010mpxS3QL4edcDtQseyXSFCnEkuo2MrRw==",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.6"
             },
             "dependencies": {
                 "source-map": {
@@ -54,10 +54,10 @@
             "dev": true,
             "requires": {
                 "@angular-devkit/core": "0.0.22",
-                "@ngtools/json-schema": "1.1.0",
+                "@ngtools/json-schema": "^1.1.0",
                 "@schematics/schematics": "0.0.11",
-                "minimist": "1.2.0",
-                "rxjs": "5.5.6"
+                "minimist": "^1.2.0",
+                "rxjs": "^5.5.2"
             }
         },
         "@angular/animations": {
@@ -65,7 +65,7 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.2.7.tgz",
             "integrity": "sha512-t/B0z2OYO+yy8SJKB1/evSNPvnLsl+AclhM1p21/NnETxQUqvct1KXeDM7nYDu5hmnGmuavhua8LDo6rN5zS+Q==",
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/cli": {
@@ -74,64 +74,64 @@
             "integrity": "sha512-X049QAgSKy5J48byyo3T6iBTHubTC66QBMshMpTT7PWAaSq3HpPPE1xW0WwgFIXZWMQIsmncaqPwmnFmxljUdw==",
             "dev": true,
             "requires": {
-                "@angular-devkit/build-optimizer": "0.0.42",
-                "@angular-devkit/schematics": "0.0.42",
+                "@angular-devkit/build-optimizer": "~0.0.35",
+                "@angular-devkit/schematics": "~0.0.40",
                 "@ngtools/json-schema": "1.1.0",
                 "@ngtools/webpack": "1.9.0",
-                "@schematics/angular": "0.1.17",
-                "autoprefixer": "6.7.7",
-                "chalk": "2.2.2",
-                "circular-dependency-plugin": "4.4.0",
-                "common-tags": "1.7.2",
-                "copy-webpack-plugin": "4.5.0",
-                "core-object": "3.1.5",
-                "css-loader": "0.28.10",
-                "cssnano": "3.10.0",
-                "denodeify": "1.2.1",
-                "ember-cli-string-utils": "1.1.0",
-                "exports-loader": "0.6.4",
-                "extract-text-webpack-plugin": "3.0.2",
-                "file-loader": "1.1.11",
-                "fs-extra": "4.0.3",
-                "glob": "7.1.2",
-                "html-webpack-plugin": "2.30.1",
-                "istanbul-instrumenter-loader": "2.0.0",
-                "karma-source-map-support": "1.2.0",
-                "less": "2.7.3",
-                "less-loader": "4.0.6",
-                "license-webpack-plugin": "1.2.3",
-                "lodash": "4.17.5",
-                "memory-fs": "0.4.1",
-                "minimatch": "3.0.4",
-                "node-modules-path": "1.0.1",
-                "node-sass": "4.7.2",
-                "nopt": "4.0.1",
-                "opn": "5.1.0",
-                "portfinder": "1.0.13",
-                "postcss-custom-properties": "6.3.1",
-                "postcss-loader": "2.1.1",
-                "postcss-url": "7.3.1",
-                "raw-loader": "0.5.1",
-                "resolve": "1.5.0",
-                "rxjs": "5.5.6",
-                "sass-loader": "6.0.7",
-                "semver": "5.5.0",
-                "silent-error": "1.1.0",
-                "source-map-loader": "0.2.3",
-                "source-map-support": "0.4.18",
-                "style-loader": "0.13.2",
-                "stylus": "0.54.5",
-                "stylus-loader": "3.0.2",
-                "uglifyjs-webpack-plugin": "1.1.8",
-                "url-loader": "0.6.2",
-                "webpack": "3.10.0",
-                "webpack-concat-plugin": "1.4.2",
-                "webpack-dev-middleware": "1.12.2",
-                "webpack-dev-server": "2.9.7",
-                "webpack-merge": "4.1.2",
-                "webpack-sources": "1.1.0",
-                "webpack-subresource-integrity": "1.0.4",
-                "zone.js": "0.8.20"
+                "@schematics/angular": "~0.1.10",
+                "autoprefixer": "^6.5.3",
+                "chalk": "~2.2.0",
+                "circular-dependency-plugin": "^4.2.1",
+                "common-tags": "^1.3.1",
+                "copy-webpack-plugin": "^4.1.1",
+                "core-object": "^3.1.0",
+                "css-loader": "^0.28.1",
+                "cssnano": "^3.10.0",
+                "denodeify": "^1.2.1",
+                "ember-cli-string-utils": "^1.0.0",
+                "exports-loader": "^0.6.3",
+                "extract-text-webpack-plugin": "^3.0.2",
+                "file-loader": "^1.1.5",
+                "fs-extra": "^4.0.0",
+                "glob": "^7.0.3",
+                "html-webpack-plugin": "^2.29.0",
+                "istanbul-instrumenter-loader": "^2.0.0",
+                "karma-source-map-support": "^1.2.0",
+                "less": "^2.7.2",
+                "less-loader": "^4.0.5",
+                "license-webpack-plugin": "^1.0.0",
+                "lodash": "^4.11.1",
+                "memory-fs": "^0.4.1",
+                "minimatch": "^3.0.4",
+                "node-modules-path": "^1.0.0",
+                "node-sass": "^4.3.0",
+                "nopt": "^4.0.1",
+                "opn": "~5.1.0",
+                "portfinder": "~1.0.12",
+                "postcss-custom-properties": "^6.1.0",
+                "postcss-loader": "^2.0.8",
+                "postcss-url": "^7.1.2",
+                "raw-loader": "^0.5.1",
+                "resolve": "^1.1.7",
+                "rxjs": "^5.5.2",
+                "sass-loader": "^6.0.3",
+                "semver": "^5.1.0",
+                "silent-error": "^1.0.0",
+                "source-map-loader": "^0.2.0",
+                "source-map-support": "^0.4.1",
+                "style-loader": "^0.13.1",
+                "stylus": "^0.54.5",
+                "stylus-loader": "^3.0.1",
+                "uglifyjs-webpack-plugin": "~1.1.2",
+                "url-loader": "^0.6.2",
+                "webpack": "~3.10.0",
+                "webpack-concat-plugin": "^1.4.2",
+                "webpack-dev-middleware": "~1.12.0",
+                "webpack-dev-server": "~2.9.3",
+                "webpack-merge": "^4.1.0",
+                "webpack-sources": "^1.0.0",
+                "webpack-subresource-integrity": "^1.0.1",
+                "zone.js": "^0.8.14"
             },
             "dependencies": {
                 "ajv": {
@@ -140,9 +140,9 @@
                     "integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "1.1.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 },
                 "ansi-regex": {
@@ -169,8 +169,8 @@
                     "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                     "dev": true,
                     "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                     }
                 },
@@ -189,8 +189,8 @@
                     "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
                     "dev": true,
                     "requires": {
-                        "loader-utils": "1.1.0",
-                        "schema-utils": "0.4.5"
+                        "loader-utils": "^1.0.2",
+                        "schema-utils": "^0.4.5"
                     }
                 },
                 "has-flag": {
@@ -205,10 +205,10 @@
                     "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "strip-bom": "3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "os-locale": {
@@ -217,9 +217,9 @@
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     }
                 },
                 "path-exists": {
@@ -228,7 +228,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -237,7 +237,7 @@
                     "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
                     "dev": true,
                     "requires": {
-                        "pify": "2.3.0"
+                        "pify": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -252,9 +252,9 @@
                     "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.2.0"
                     },
                     "dependencies": {
                         "chalk": {
@@ -263,9 +263,9 @@
                             "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
                             "dev": true,
                             "requires": {
-                                "ansi-styles": "3.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "5.3.0"
+                                "ansi-styles": "^3.2.1",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^5.3.0"
                             }
                         }
                     }
@@ -276,10 +276,10 @@
                     "integrity": "sha512-f0J/DWE/hyO9/LH0WHpXkny/ZZ238sSaG3p1SRBtVZnFWUtD7GXIEgHoBg8cnAeRbmEvUxHQptY46zWfwNYj/w==",
                     "dev": true,
                     "requires": {
-                        "loader-utils": "1.1.0",
-                        "postcss": "6.0.19",
-                        "postcss-load-config": "1.2.0",
-                        "schema-utils": "0.4.5"
+                        "loader-utils": "^1.1.0",
+                        "postcss": "^6.0.0",
+                        "postcss-load-config": "^1.2.0",
+                        "schema-utils": "^0.4.0"
                     }
                 },
                 "postcss-url": {
@@ -288,11 +288,11 @@
                     "integrity": "sha512-Ya5KIjGptgz0OtrVYfi2UbLxVAZ6Emc4Of+Grx4Sf1deWlRpFwLr8FrtkUxfqh+XiZIVkXbjQrddE10ESpNmdA==",
                     "dev": true,
                     "requires": {
-                        "mime": "1.6.0",
-                        "minimatch": "3.0.4",
-                        "mkdirp": "0.5.1",
-                        "postcss": "6.0.19",
-                        "xxhashjs": "0.2.2"
+                        "mime": "^1.4.1",
+                        "minimatch": "^3.0.4",
+                        "mkdirp": "^0.5.0",
+                        "postcss": "^6.0.1",
+                        "xxhashjs": "^0.2.1"
                     }
                 },
                 "read-pkg": {
@@ -301,9 +301,9 @@
                     "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "2.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "2.0.0"
+                        "load-json-file": "^2.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^2.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -312,8 +312,8 @@
                     "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
                     "dev": true,
                     "requires": {
-                        "find-up": "2.1.0",
-                        "read-pkg": "2.0.0"
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^2.0.0"
                     }
                 },
                 "schema-utils": {
@@ -322,8 +322,8 @@
                     "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
                     "dev": true,
                     "requires": {
-                        "ajv": "6.2.1",
-                        "ajv-keywords": "3.1.0"
+                        "ajv": "^6.1.0",
+                        "ajv-keywords": "^3.1.0"
                     }
                 },
                 "source-map-support": {
@@ -332,7 +332,7 @@
                     "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7"
+                        "source-map": "^0.5.6"
                     },
                     "dependencies": {
                         "source-map": {
@@ -349,8 +349,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     },
                     "dependencies": {
                         "is-fullwidth-code-point": {
@@ -365,7 +365,7 @@
                             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "ansi-regex": "^3.0.0"
                             }
                         }
                     }
@@ -382,7 +382,7 @@
                     "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 },
                 "uglify-js": {
@@ -391,9 +391,9 @@
                     "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
                     },
                     "dependencies": {
                         "source-map": {
@@ -408,9 +408,9 @@
                             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                             "dev": true,
                             "requires": {
-                                "camelcase": "1.2.1",
-                                "cliui": "2.1.0",
-                                "decamelize": "1.2.0",
+                                "camelcase": "^1.0.2",
+                                "cliui": "^2.1.0",
+                                "decamelize": "^1.0.0",
                                 "window-size": "0.1.0"
                             }
                         }
@@ -422,9 +422,9 @@
                     "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
                     "dev": true,
                     "requires": {
-                        "loader-utils": "1.1.0",
-                        "mime": "1.6.0",
-                        "schema-utils": "0.3.0"
+                        "loader-utils": "^1.0.2",
+                        "mime": "^1.4.1",
+                        "schema-utils": "^0.3.0"
                     },
                     "dependencies": {
                         "ajv": {
@@ -433,10 +433,10 @@
                             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
                             "dev": true,
                             "requires": {
-                                "co": "4.6.0",
-                                "fast-deep-equal": "1.1.0",
-                                "fast-json-stable-stringify": "2.0.0",
-                                "json-schema-traverse": "0.3.1"
+                                "co": "^4.6.0",
+                                "fast-deep-equal": "^1.0.0",
+                                "fast-json-stable-stringify": "^2.0.0",
+                                "json-schema-traverse": "^0.3.0"
                             }
                         },
                         "schema-utils": {
@@ -445,7 +445,7 @@
                             "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
                             "dev": true,
                             "requires": {
-                                "ajv": "5.5.2"
+                                "ajv": "^5.0.0"
                             }
                         }
                     }
@@ -456,28 +456,28 @@
                     "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
                     "dev": true,
                     "requires": {
-                        "acorn": "5.5.0",
-                        "acorn-dynamic-import": "2.0.2",
-                        "ajv": "5.5.2",
-                        "ajv-keywords": "2.1.1",
-                        "async": "2.6.0",
-                        "enhanced-resolve": "3.4.1",
-                        "escope": "3.6.0",
-                        "interpret": "1.1.0",
-                        "json-loader": "0.5.7",
-                        "json5": "0.5.1",
-                        "loader-runner": "2.3.0",
-                        "loader-utils": "1.1.0",
-                        "memory-fs": "0.4.1",
-                        "mkdirp": "0.5.1",
-                        "node-libs-browser": "2.1.0",
-                        "source-map": "0.5.7",
-                        "supports-color": "4.5.0",
-                        "tapable": "0.2.8",
-                        "uglifyjs-webpack-plugin": "0.4.6",
-                        "watchpack": "1.5.0",
-                        "webpack-sources": "1.1.0",
-                        "yargs": "8.0.2"
+                        "acorn": "^5.0.0",
+                        "acorn-dynamic-import": "^2.0.0",
+                        "ajv": "^5.1.5",
+                        "ajv-keywords": "^2.0.0",
+                        "async": "^2.1.2",
+                        "enhanced-resolve": "^3.4.0",
+                        "escope": "^3.6.0",
+                        "interpret": "^1.0.0",
+                        "json-loader": "^0.5.4",
+                        "json5": "^0.5.1",
+                        "loader-runner": "^2.3.0",
+                        "loader-utils": "^1.1.0",
+                        "memory-fs": "~0.4.1",
+                        "mkdirp": "~0.5.0",
+                        "node-libs-browser": "^2.0.0",
+                        "source-map": "^0.5.3",
+                        "supports-color": "^4.2.1",
+                        "tapable": "^0.2.7",
+                        "uglifyjs-webpack-plugin": "^0.4.6",
+                        "watchpack": "^1.4.0",
+                        "webpack-sources": "^1.0.1",
+                        "yargs": "^8.0.2"
                     },
                     "dependencies": {
                         "ajv": {
@@ -486,10 +486,10 @@
                             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
                             "dev": true,
                             "requires": {
-                                "co": "4.6.0",
-                                "fast-deep-equal": "1.1.0",
-                                "fast-json-stable-stringify": "2.0.0",
-                                "json-schema-traverse": "0.3.1"
+                                "co": "^4.6.0",
+                                "fast-deep-equal": "^1.0.0",
+                                "fast-json-stable-stringify": "^2.0.0",
+                                "json-schema-traverse": "^0.3.0"
                             }
                         },
                         "ajv-keywords": {
@@ -516,7 +516,7 @@
                             "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                             "dev": true,
                             "requires": {
-                                "has-flag": "2.0.0"
+                                "has-flag": "^2.0.0"
                             }
                         },
                         "uglifyjs-webpack-plugin": {
@@ -525,9 +525,9 @@
                             "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
                             "dev": true,
                             "requires": {
-                                "source-map": "0.5.7",
-                                "uglify-js": "2.8.29",
-                                "webpack-sources": "1.1.0"
+                                "source-map": "^0.5.6",
+                                "uglify-js": "^2.8.29",
+                                "webpack-sources": "^1.0.1"
                             }
                         }
                     }
@@ -538,8 +538,8 @@
                     "integrity": "sha512-HdV2xOq4twtL2ThR9NSCCQ888v1JBMpJfm3k2mA1I5LkS2+/6rv8q/bb9yTSaR0fVaMtANZi4Wkz0xc33MAt6w==",
                     "dev": true,
                     "requires": {
-                        "md5": "2.2.1",
-                        "uglify-js": "2.8.29"
+                        "md5": "^2.2.1",
+                        "uglify-js": "^2.8.29"
                     }
                 },
                 "webpack-dev-server": {
@@ -549,32 +549,32 @@
                     "dev": true,
                     "requires": {
                         "ansi-html": "0.0.7",
-                        "array-includes": "3.0.3",
-                        "bonjour": "3.5.0",
-                        "chokidar": "1.7.0",
-                        "compression": "1.7.2",
-                        "connect-history-api-fallback": "1.5.0",
-                        "debug": "3.1.0",
-                        "del": "3.0.0",
-                        "express": "4.16.2",
-                        "html-entities": "1.2.1",
-                        "http-proxy-middleware": "0.17.4",
-                        "import-local": "0.1.1",
+                        "array-includes": "^3.0.3",
+                        "bonjour": "^3.5.0",
+                        "chokidar": "^1.6.0",
+                        "compression": "^1.5.2",
+                        "connect-history-api-fallback": "^1.3.0",
+                        "debug": "^3.1.0",
+                        "del": "^3.0.0",
+                        "express": "^4.16.2",
+                        "html-entities": "^1.2.0",
+                        "http-proxy-middleware": "~0.17.4",
+                        "import-local": "^0.1.1",
                         "internal-ip": "1.2.0",
-                        "ip": "1.1.5",
-                        "killable": "1.0.0",
-                        "loglevel": "1.6.1",
-                        "opn": "5.1.0",
-                        "portfinder": "1.0.13",
-                        "selfsigned": "1.10.2",
-                        "serve-index": "1.9.1",
+                        "ip": "^1.1.5",
+                        "killable": "^1.0.0",
+                        "loglevel": "^1.4.1",
+                        "opn": "^5.1.0",
+                        "portfinder": "^1.0.9",
+                        "selfsigned": "^1.9.1",
+                        "serve-index": "^1.7.2",
                         "sockjs": "0.3.18",
                         "sockjs-client": "1.1.4",
-                        "spdy": "3.4.7",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "4.5.0",
-                        "webpack-dev-middleware": "1.12.2",
-                        "yargs": "6.6.0"
+                        "spdy": "^3.4.1",
+                        "strip-ansi": "^3.0.1",
+                        "supports-color": "^4.2.1",
+                        "webpack-dev-middleware": "^1.11.0",
+                        "yargs": "^6.6.0"
                     },
                     "dependencies": {
                         "camelcase": {
@@ -589,9 +589,9 @@
                             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                             "dev": true,
                             "requires": {
-                                "string-width": "1.0.2",
-                                "strip-ansi": "3.0.1",
-                                "wrap-ansi": "2.1.0"
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wrap-ansi": "^2.0.0"
                             }
                         },
                         "find-up": {
@@ -600,8 +600,8 @@
                             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                             "dev": true,
                             "requires": {
-                                "path-exists": "2.1.0",
-                                "pinkie-promise": "2.0.1"
+                                "path-exists": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
                             }
                         },
                         "has-flag": {
@@ -616,11 +616,11 @@
                             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                             "dev": true,
                             "requires": {
-                                "graceful-fs": "4.1.11",
-                                "parse-json": "2.2.0",
-                                "pify": "2.3.0",
-                                "pinkie-promise": "2.0.1",
-                                "strip-bom": "2.0.0"
+                                "graceful-fs": "^4.1.2",
+                                "parse-json": "^2.2.0",
+                                "pify": "^2.0.0",
+                                "pinkie-promise": "^2.0.0",
+                                "strip-bom": "^2.0.0"
                             }
                         },
                         "os-locale": {
@@ -629,7 +629,7 @@
                             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
                             "dev": true,
                             "requires": {
-                                "lcid": "1.0.0"
+                                "lcid": "^1.0.0"
                             }
                         },
                         "path-type": {
@@ -638,9 +638,9 @@
                             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                             "dev": true,
                             "requires": {
-                                "graceful-fs": "4.1.11",
-                                "pify": "2.3.0",
-                                "pinkie-promise": "2.0.1"
+                                "graceful-fs": "^4.1.2",
+                                "pify": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
                             }
                         },
                         "read-pkg": {
@@ -649,9 +649,9 @@
                             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                             "dev": true,
                             "requires": {
-                                "load-json-file": "1.1.0",
-                                "normalize-package-data": "2.4.0",
-                                "path-type": "1.1.0"
+                                "load-json-file": "^1.0.0",
+                                "normalize-package-data": "^2.3.2",
+                                "path-type": "^1.0.0"
                             }
                         },
                         "read-pkg-up": {
@@ -660,8 +660,8 @@
                             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                             "dev": true,
                             "requires": {
-                                "find-up": "1.1.2",
-                                "read-pkg": "1.1.0"
+                                "find-up": "^1.0.0",
+                                "read-pkg": "^1.0.0"
                             }
                         },
                         "string-width": {
@@ -670,9 +670,9 @@
                             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                             "dev": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             }
                         },
                         "strip-bom": {
@@ -681,7 +681,7 @@
                             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                             "dev": true,
                             "requires": {
-                                "is-utf8": "0.2.1"
+                                "is-utf8": "^0.2.0"
                             }
                         },
                         "supports-color": {
@@ -690,7 +690,7 @@
                             "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                             "dev": true,
                             "requires": {
-                                "has-flag": "2.0.0"
+                                "has-flag": "^2.0.0"
                             }
                         },
                         "which-module": {
@@ -705,19 +705,19 @@
                             "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
                             "dev": true,
                             "requires": {
-                                "camelcase": "3.0.0",
-                                "cliui": "3.2.0",
-                                "decamelize": "1.2.0",
-                                "get-caller-file": "1.0.2",
-                                "os-locale": "1.4.0",
-                                "read-pkg-up": "1.0.1",
-                                "require-directory": "2.1.1",
-                                "require-main-filename": "1.0.1",
-                                "set-blocking": "2.0.0",
-                                "string-width": "1.0.2",
-                                "which-module": "1.0.0",
-                                "y18n": "3.2.1",
-                                "yargs-parser": "4.2.1"
+                                "camelcase": "^3.0.0",
+                                "cliui": "^3.2.0",
+                                "decamelize": "^1.1.1",
+                                "get-caller-file": "^1.0.1",
+                                "os-locale": "^1.4.0",
+                                "read-pkg-up": "^1.0.1",
+                                "require-directory": "^2.1.1",
+                                "require-main-filename": "^1.0.1",
+                                "set-blocking": "^2.0.0",
+                                "string-width": "^1.0.2",
+                                "which-module": "^1.0.0",
+                                "y18n": "^3.2.1",
+                                "yargs-parser": "^4.2.0"
                             }
                         },
                         "yargs-parser": {
@@ -726,7 +726,7 @@
                             "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                             "dev": true,
                             "requires": {
-                                "camelcase": "3.0.0"
+                                "camelcase": "^3.0.0"
                             }
                         }
                     }
@@ -749,19 +749,19 @@
                     "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "2.1.0",
-                        "read-pkg-up": "2.0.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "7.0.0"
+                        "camelcase": "^4.1.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "read-pkg-up": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^7.0.0"
                     },
                     "dependencies": {
                         "camelcase": {
@@ -776,9 +776,9 @@
                             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                             "dev": true,
                             "requires": {
-                                "string-width": "1.0.2",
-                                "strip-ansi": "3.0.1",
-                                "wrap-ansi": "2.1.0"
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wrap-ansi": "^2.0.0"
                             },
                             "dependencies": {
                                 "string-width": {
@@ -787,9 +787,9 @@
                                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                                     "dev": true,
                                     "requires": {
-                                        "code-point-at": "1.1.0",
-                                        "is-fullwidth-code-point": "1.0.0",
-                                        "strip-ansi": "3.0.1"
+                                        "code-point-at": "^1.0.0",
+                                        "is-fullwidth-code-point": "^1.0.0",
+                                        "strip-ansi": "^3.0.0"
                                     }
                                 }
                             }
@@ -802,7 +802,7 @@
                     "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     },
                     "dependencies": {
                         "camelcase": {
@@ -820,7 +820,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-5.2.7.tgz",
             "integrity": "sha512-TqsDMmPX1JlEH2QIneuAVzEO4ubzxLBAdV4XbKWDQKC/UfbWIIpSrSp2cIi85NV1tKkg0WAaodCIZ02NucHIHg==",
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/compiler": {
@@ -828,7 +828,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.2.7.tgz",
             "integrity": "sha512-26RG+Dy+M/95OyNNqM+OAruarIPOmbndiaglz2dMrNYzenfbSgG/AoPlL5uCdSqZDiXgnlKnS2K6/ePWXDSKNw==",
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/compiler-cli": {
@@ -836,10 +836,10 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.2.7.tgz",
             "integrity": "sha512-91gQolzsKyOlmBNW1J7lyu+dXHe/KHbAXU459hn6rycMHuTt60XvxA5O3xy3Pqt28VgbOOSrQfq5eVjZodKjWg==",
             "requires": {
-                "chokidar": "1.7.0",
-                "minimist": "1.2.0",
-                "reflect-metadata": "0.1.12",
-                "tsickle": "0.27.2"
+                "chokidar": "^1.4.2",
+                "minimist": "^1.2.0",
+                "reflect-metadata": "^0.1.2",
+                "tsickle": "^0.27.2"
             },
             "dependencies": {
                 "tsickle": {
@@ -847,10 +847,10 @@
                     "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.27.2.tgz",
                     "integrity": "sha512-KW+ZgY0t2cq2Qib1sfdgMiRnk+cr3brUtzZoVWjv+Ot3jNxVorFBUH+6In6hl8Dg7BI2AAFf69NHkwvZNMSFwA==",
                     "requires": {
-                        "minimist": "1.2.0",
-                        "mkdirp": "0.5.1",
-                        "source-map": "0.6.1",
-                        "source-map-support": "0.5.3"
+                        "minimist": "^1.2.0",
+                        "mkdirp": "^0.5.1",
+                        "source-map": "^0.6.0",
+                        "source-map-support": "^0.5.0"
                     }
                 }
             }
@@ -860,7 +860,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.2.7.tgz",
             "integrity": "sha512-DQuL6n7cjBfZmWX5RCV271g6PW9N8b93g2skWnM/zjm+BL9tfHPgvmsjMNB7QEHSxW8VBaaQ6gjj422O01A87g==",
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/forms": {
@@ -868,7 +868,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.2.7.tgz",
             "integrity": "sha512-43oLKdzMjMV/hOLpSTg8aOggcx+veTnPp/JN+KzMGo2qtbim5nk3fnuscWDeDOdkh8hPRPGarKxeFNEE9ZZSTg==",
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/platform-browser": {
@@ -876,7 +876,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.2.7.tgz",
             "integrity": "sha512-SdLx4F6tOy4/s3y1KZ/Z3YA6fiIrydaO2bry2FJglDxJh24p6TZIob+zC16N2MTuFW819KY5OlacNhc8aj6Yag==",
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/platform-browser-dynamic": {
@@ -884,7 +884,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.2.7.tgz",
             "integrity": "sha512-95Rwf1JcGF/BI48k+VG2moLTVC863jPSjmHaGkz7cA9bi/QrRFGvFghl1qIm4Ezp3dj8CH8TE3TWB+1AmAg3AQ==",
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@angular/router": {
@@ -892,7 +892,7 @@
             "resolved": "https://registry.npmjs.org/@angular/router/-/router-5.2.7.tgz",
             "integrity": "sha512-ppl0X7EfEgKYXIEPtdy8cOKj5KXuwCQ5Ila+IuGnSjKIRXt/olhBLJMprVl1VJgoxXj7z2i14U7kKaqSvGtpXw==",
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.7.1"
             }
         },
         "@ngtools/json-schema": {
@@ -907,13 +907,13 @@
             "integrity": "sha512-+9EFOELj9D7zarsKTiIFSbTL2Pr3jYdRJ/cEuSoTxzZUDq7f3urq9ILbcy3DTaDlZs2CCYKwgz+In8QnDtw4fg==",
             "dev": true,
             "requires": {
-                "chalk": "2.2.2",
-                "enhanced-resolve": "3.4.1",
-                "loader-utils": "1.1.0",
-                "magic-string": "0.22.4",
-                "semver": "5.5.0",
-                "source-map": "0.5.7",
-                "tree-kill": "1.2.0"
+                "chalk": "~2.2.0",
+                "enhanced-resolve": "^3.1.0",
+                "loader-utils": "^1.0.2",
+                "magic-string": "^0.22.3",
+                "semver": "^5.3.0",
+                "source-map": "^0.5.6",
+                "tree-kill": "^1.0.0"
             },
             "dependencies": {
                 "source-map": {
@@ -930,7 +930,7 @@
             "integrity": "sha512-PHE5gk/ogPY/aN94dbbtauHMCq+/7w4Kdcl7tGmSS8mPKEI0wa6XJi//Wq/tHi55lb2fP58oEZU6n6w/wQascw==",
             "dev": true,
             "requires": {
-                "typescript": "2.6.2"
+                "typescript": "~2.6.2"
             },
             "dependencies": {
                 "typescript": {
@@ -953,7 +953,7 @@
             "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
             "dev": true,
             "requires": {
-                "commander": "2.14.1"
+                "commander": "*"
             }
         },
         "@types/jasmine": {
@@ -968,7 +968,7 @@
             "integrity": "sha1-lw/iF7KSFerboMk/7IdpkziQJL0=",
             "dev": true,
             "requires": {
-                "@types/jasmine": "2.5.54"
+                "@types/jasmine": "*"
             }
         },
         "@types/node": {
@@ -1000,7 +1000,7 @@
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "dev": true,
             "requires": {
-                "mime-types": "2.1.18",
+                "mime-types": "~2.1.18",
                 "negotiator": "0.6.1"
             }
         },
@@ -1016,7 +1016,7 @@
             "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
             "dev": true,
             "requires": {
-                "acorn": "4.0.13"
+                "acorn": "^4.0.3"
             },
             "dependencies": {
                 "acorn": {
@@ -1051,8 +1051,8 @@
             "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "semver": "5.0.3"
+                "extend": "~3.0.0",
+                "semver": "~5.0.1"
             },
             "dependencies": {
                 "semver": {
@@ -1069,10 +1069,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ajv-keywords": {
@@ -1087,9 +1087,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             }
         },
         "alphanum-sort": {
@@ -1110,7 +1110,7 @@
             "integrity": "sha1-wNROkP/w+sleiyPwQ6zaf9HFHXw=",
             "dev": true,
             "requires": {
-                "loader-utils": "0.2.17"
+                "loader-utils": "^0.2.15"
             },
             "dependencies": {
                 "loader-utils": {
@@ -1119,10 +1119,10 @@
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1",
-                        "object-assign": "4.1.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0",
+                        "object-assign": "^4.0.1"
                     }
                 }
             }
@@ -1133,7 +1133,7 @@
             "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
             "dev": true,
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -1154,8 +1154,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -1164,7 +1164,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -1187,7 +1187,7 @@
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
-                "color-convert": "1.9.1"
+                "color-convert": "^1.9.0"
             }
         },
         "anymatch": {
@@ -1195,8 +1195,8 @@
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "requires": {
-                "micromatch": "2.3.11",
-                "normalize-path": "2.1.1"
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
             }
         },
         "append-transform": {
@@ -1205,7 +1205,7 @@
             "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
             "dev": true,
             "requires": {
-                "default-require-extensions": "1.0.0"
+                "default-require-extensions": "^1.0.0"
             }
         },
         "aproba": {
@@ -1220,15 +1220,15 @@
             "integrity": "sha1-TyGU1tj5nfP1MeaIHxTxXVX6ryI=",
             "dev": true,
             "requires": {
-                "archiver-utils": "1.3.0",
-                "async": "2.6.0",
-                "buffer-crc32": "0.2.13",
-                "glob": "7.1.2",
-                "lodash": "4.17.5",
-                "readable-stream": "2.3.5",
-                "tar-stream": "1.5.5",
-                "walkdir": "0.0.11",
-                "zip-stream": "1.2.0"
+                "archiver-utils": "^1.3.0",
+                "async": "^2.0.0",
+                "buffer-crc32": "^0.2.1",
+                "glob": "^7.0.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0",
+                "tar-stream": "^1.5.0",
+                "walkdir": "^0.0.11",
+                "zip-stream": "^1.1.0"
             }
         },
         "archiver-utils": {
@@ -1237,12 +1237,12 @@
             "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lazystream": "1.0.0",
-                "lodash": "4.17.5",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.5"
+                "glob": "^7.0.0",
+                "graceful-fs": "^4.1.0",
+                "lazystream": "^1.0.0",
+                "lodash": "^4.8.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "are-we-there-yet": {
@@ -1251,8 +1251,8 @@
             "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
             "dev": true,
             "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.5"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
             }
         },
         "argparse": {
@@ -1261,7 +1261,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -1269,7 +1269,7 @@
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1"
             }
         },
         "arr-flatten": {
@@ -1307,8 +1307,8 @@
             "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.10.0"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.7.0"
             }
         },
         "array-map": {
@@ -1335,7 +1335,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -1379,9 +1379,9 @@
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "assert": {
@@ -1417,7 +1417,7 @@
             "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.5"
+                "lodash": "^4.14.0"
             }
         },
         "async-each": {
@@ -1461,12 +1461,12 @@
             "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000812",
-                "normalize-range": "0.1.2",
-                "num2fraction": "1.2.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "browserslist": "^1.7.6",
+                "caniuse-db": "^1.0.30000634",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^5.2.16",
+                "postcss-value-parser": "^3.2.3"
             }
         },
         "awesome-typescript-loader": {
@@ -1475,13 +1475,13 @@
             "integrity": "sha512-qzgm9SEvodVkSi9QY7Me1/rujg+YBNMjayNSAyzNghwTEez++gXoPCwMvpbHRG7wrOkDCiF6dquvv9ESmUBAuw==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
+                "chalk": "^2.3.1",
                 "enhanced-resolve": "3.3.0",
-                "loader-utils": "1.1.0",
-                "lodash": "4.17.5",
-                "micromatch": "3.1.9",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.5.3"
+                "loader-utils": "^1.1.0",
+                "lodash": "^4.17.4",
+                "micromatch": "^3.0.3",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.3"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1502,18 +1502,18 @@
                     "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "kind-of": "6.0.2",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.1",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "kind-of": "^6.0.2",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -1522,7 +1522,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -1542,9 +1542,9 @@
                     "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "enhanced-resolve": {
@@ -1553,10 +1553,10 @@
                     "integrity": "sha512-2qbxE7ek3YxPJ1ML6V+satHkzHpJQKWkRHmRx6mfAoW59yP8YH8BFplbegSP+u2hBd6B6KCOpvJQ3dZAP+hkpg==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "memory-fs": "0.4.1",
-                        "object-assign": "4.1.1",
-                        "tapable": "0.2.8"
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.4.0",
+                        "object-assign": "^4.0.1",
+                        "tapable": "^0.2.5"
                     }
                 },
                 "expand-brackets": {
@@ -1682,7 +1682,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1691,7 +1691,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1702,7 +1702,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1711,7 +1711,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1754,19 +1754,19 @@
                     "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.1",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.1",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     }
                 },
                 "supports-color": {
@@ -1775,7 +1775,7 @@
                     "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -1798,9 +1798,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -1815,11 +1815,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -1836,14 +1836,14 @@
             "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
             "dev": true,
             "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.5",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
             },
             "dependencies": {
                 "jsesc": {
@@ -1866,7 +1866,7 @@
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-runtime": {
@@ -1875,8 +1875,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "2.5.3",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
             }
         },
         "babel-template": {
@@ -1885,11 +1885,11 @@
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "lodash": "4.17.5"
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-traverse": {
@@ -1898,15 +1898,15 @@
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.3",
-                "lodash": "4.17.5"
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
             }
         },
         "babel-types": {
@@ -1915,10 +1915,10 @@
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.5",
-                "to-fast-properties": "1.0.3"
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
             }
         },
         "babylon": {
@@ -1944,13 +1944,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1959,7 +1959,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "isobject": {
@@ -2001,7 +2001,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "better-assert": {
@@ -2030,7 +2030,7 @@
             "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.5"
             }
         },
         "blob": {
@@ -2045,7 +2045,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "bluebird": {
@@ -2067,15 +2067,15 @@
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "http-errors": "1.6.2",
+                "depd": "~1.1.1",
+                "http-errors": "~1.6.2",
                 "iconv-lite": "0.4.19",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.5.1",
                 "raw-body": "2.3.2",
-                "type-is": "1.6.16"
+                "type-is": "~1.6.15"
             },
             "dependencies": {
                 "qs": {
@@ -2092,12 +2092,12 @@
             "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
             "dev": true,
             "requires": {
-                "array-flatten": "2.1.1",
-                "deep-equal": "1.0.1",
-                "dns-equal": "1.0.0",
-                "dns-txt": "2.0.2",
-                "multicast-dns": "6.2.3",
-                "multicast-dns-service-types": "1.1.0"
+                "array-flatten": "^2.1.0",
+                "deep-equal": "^1.0.1",
+                "dns-equal": "^1.0.0",
+                "dns-txt": "^2.0.2",
+                "multicast-dns": "^6.0.1",
+                "multicast-dns-service-types": "^1.1.0"
             }
         },
         "boolbase": {
@@ -2112,7 +2112,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "bootstrap": {
@@ -2120,8 +2120,8 @@
             "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0-alpha.5.tgz",
             "integrity": "sha1-oSa2SMO9L1K4+tS7xeLQrSq/cGQ=",
             "requires": {
-                "jquery": "3.3.1",
-                "tether": "1.4.3"
+                "jquery": "1.9.1 - 3",
+                "tether": "^1.3.7"
             }
         },
         "boxen": {
@@ -2130,13 +2130,13 @@
             "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
             "dev": true,
             "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.2.2",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "2.0.0"
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2163,8 +2163,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -2173,7 +2173,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -2183,7 +2183,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -2192,9 +2192,9 @@
             "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "brorand": {
@@ -2209,17 +2209,17 @@
             "integrity": "sha512-loCO5NQKZXfBJrEvmLwF1TPSECCsPopNd29qduoysLmpw8op2lgolGMjz3oI/MjG4duzB9TfDs7k58djRSwPwg==",
             "dev": true,
             "requires": {
-                "browser-sync-ui": "1.0.1",
+                "browser-sync-ui": "v1.0.1",
                 "bs-recipes": "1.3.4",
                 "chokidar": "1.7.0",
                 "connect": "3.5.0",
-                "connect-history-api-fallback": "1.5.0",
-                "dev-ip": "1.0.1",
+                "connect-history-api-fallback": "^1.5.0",
+                "dev-ip": "^1.0.1",
                 "easy-extender": "2.3.2",
                 "eazy-logger": "3.0.2",
-                "emitter-steward": "1.0.0",
-                "etag": "1.8.1",
-                "fresh": "0.5.2",
+                "emitter-steward": "^1.0.0",
+                "etag": "^1.8.1",
+                "fresh": "^0.5.2",
                 "fs-extra": "3.0.1",
                 "http-proxy": "1.15.2",
                 "immutable": "3.8.2",
@@ -2317,14 +2317,14 @@
                     "requires": {
                         "component-emitter": "1.2.1",
                         "component-inherit": "0.0.3",
-                        "debug": "3.1.0",
-                        "engine.io-parser": "2.1.2",
+                        "debug": "~3.1.0",
+                        "engine.io-parser": "~2.1.1",
                         "has-cors": "1.1.0",
                         "indexof": "0.0.1",
                         "parseqs": "0.0.5",
                         "parseuri": "0.0.5",
-                        "ws": "3.3.3",
-                        "xmlhttprequest-ssl": "1.5.5",
+                        "ws": "~3.3.1",
+                        "xmlhttprequest-ssl": "~1.5.4",
                         "yeast": "0.1.2"
                     },
                     "dependencies": {
@@ -2453,18 +2453,18 @@
                     "dev": true,
                     "requires": {
                         "debug": "2.6.4",
-                        "depd": "1.1.2",
-                        "destroy": "1.0.4",
-                        "encodeurl": "1.0.2",
-                        "escape-html": "1.0.3",
-                        "etag": "1.8.1",
+                        "depd": "~1.1.0",
+                        "destroy": "~1.0.4",
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "etag": "~1.8.0",
                         "fresh": "0.5.0",
-                        "http-errors": "1.6.2",
+                        "http-errors": "~1.6.1",
                         "mime": "1.3.4",
                         "ms": "1.0.0",
-                        "on-finished": "2.3.0",
-                        "range-parser": "1.2.0",
-                        "statuses": "1.3.1"
+                        "on-finished": "~2.3.0",
+                        "range-parser": "~1.2.0",
+                        "statuses": "~1.3.1"
                     },
                     "dependencies": {
                         "debug": {
@@ -2499,7 +2499,7 @@
                                 "depd": "1.1.1",
                                 "inherits": "2.0.3",
                                 "setprototypeof": "1.0.3",
-                                "statuses": "1.3.1"
+                                "statuses": ">= 1.3.1 < 2"
                             },
                             "dependencies": {
                                 "depd": {
@@ -2545,9 +2545,9 @@
                     "integrity": "sha1-5UbicmCBuBtLzsjpCAjrzdMjr7o=",
                     "dev": true,
                     "requires": {
-                        "encodeurl": "1.0.2",
-                        "escape-html": "1.0.3",
-                        "parseurl": "1.3.2",
+                        "encodeurl": "~1.0.1",
+                        "escape-html": "~1.0.3",
+                        "parseurl": "~1.3.1",
                         "send": "0.15.2"
                     }
                 },
@@ -2741,11 +2741,11 @@
             "dev": true,
             "requires": {
                 "async-each-series": "0.1.1",
-                "connect-history-api-fallback": "1.5.0",
-                "immutable": "3.8.2",
+                "connect-history-api-fallback": "^1.1.0",
+                "immutable": "^3.7.6",
                 "server-destroy": "1.0.1",
                 "socket.io-client": "2.0.4",
-                "stream-throttle": "0.1.3"
+                "stream-throttle": "^0.1.3"
             },
             "dependencies": {
                 "arraybuffer.slice": {
@@ -2762,14 +2762,14 @@
                     "requires": {
                         "component-emitter": "1.2.1",
                         "component-inherit": "0.0.3",
-                        "debug": "3.1.0",
-                        "engine.io-parser": "2.1.2",
+                        "debug": "~3.1.0",
+                        "engine.io-parser": "~2.1.1",
                         "has-cors": "1.1.0",
                         "indexof": "0.0.1",
                         "parseqs": "0.0.5",
                         "parseuri": "0.0.5",
-                        "ws": "3.3.3",
-                        "xmlhttprequest-ssl": "1.5.5",
+                        "ws": "~3.3.1",
+                        "xmlhttprequest-ssl": "~1.5.4",
                         "yeast": "0.1.2"
                     },
                     "dependencies": {
@@ -2791,10 +2791,10 @@
                     "dev": true,
                     "requires": {
                         "after": "0.8.2",
-                        "arraybuffer.slice": "0.0.7",
+                        "arraybuffer.slice": "~0.0.7",
                         "base64-arraybuffer": "0.1.5",
                         "blob": "0.0.4",
-                        "has-binary2": "1.0.2"
+                        "has-binary2": "~1.0.2"
                     }
                 },
                 "isarray": {
@@ -2813,14 +2813,14 @@
                         "base64-arraybuffer": "0.1.5",
                         "component-bind": "1.0.0",
                         "component-emitter": "1.2.1",
-                        "debug": "2.6.9",
-                        "engine.io-client": "3.1.5",
+                        "debug": "~2.6.4",
+                        "engine.io-client": "~3.1.0",
                         "has-cors": "1.1.0",
                         "indexof": "0.0.1",
                         "object-component": "0.0.3",
                         "parseqs": "0.0.5",
                         "parseuri": "0.0.5",
-                        "socket.io-parser": "3.1.3",
+                        "socket.io-parser": "~3.1.1",
                         "to-array": "0.1.4"
                     }
                 },
@@ -2831,8 +2831,8 @@
                     "dev": true,
                     "requires": {
                         "component-emitter": "1.2.1",
-                        "debug": "3.1.0",
-                        "has-binary2": "1.0.2",
+                        "debug": "~3.1.0",
+                        "has-binary2": "~1.0.2",
                         "isarray": "2.0.1"
                     },
                     "dependencies": {
@@ -2859,9 +2859,9 @@
                     "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
                     "dev": true,
                     "requires": {
-                        "async-limiter": "1.0.0",
-                        "safe-buffer": "5.1.1",
-                        "ultron": "1.1.1"
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
                     }
                 },
                 "xmlhttprequest-ssl": {
@@ -2878,12 +2878,12 @@
             "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
             "dev": true,
             "requires": {
-                "buffer-xor": "1.0.3",
-                "cipher-base": "1.0.4",
-                "create-hash": "1.1.3",
-                "evp_bytestokey": "1.0.3",
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "browserify-cipher": {
@@ -2892,9 +2892,9 @@
             "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
             "dev": true,
             "requires": {
-                "browserify-aes": "1.1.1",
-                "browserify-des": "1.0.0",
-                "evp_bytestokey": "1.0.3"
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
             }
         },
         "browserify-des": {
@@ -2903,9 +2903,9 @@
             "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "des.js": "1.0.0",
-                "inherits": "2.0.3"
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "browserify-rsa": {
@@ -2914,8 +2914,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
             }
         },
         "browserify-sign": {
@@ -2924,13 +2924,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "elliptic": "6.4.0",
-                "inherits": "2.0.3",
-                "parse-asn1": "5.1.0"
+                "bn.js": "^4.1.1",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.2",
+                "elliptic": "^6.0.0",
+                "inherits": "^2.0.1",
+                "parse-asn1": "^5.0.0"
             }
         },
         "browserify-zlib": {
@@ -2939,7 +2939,7 @@
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
-                "pako": "1.0.6"
+                "pako": "~1.0.5"
             }
         },
         "browserslist": {
@@ -2948,8 +2948,8 @@
             "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
             "dev": true,
             "requires": {
-                "caniuse-db": "1.0.30000812",
-                "electron-to-chromium": "1.3.34"
+                "caniuse-db": "^1.0.30000639",
+                "electron-to-chromium": "^1.2.7"
             }
         },
         "bs-recipes": {
@@ -2964,9 +2964,9 @@
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
-                "base64-js": "1.2.3",
-                "ieee754": "1.1.8",
-                "isarray": "1.0.0"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
             }
         },
         "buffer-crc32": {
@@ -3011,19 +3011,19 @@
             "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "chownr": "1.0.1",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lru-cache": "4.1.1",
-                "mississippi": "2.0.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "promise-inflight": "1.0.1",
-                "rimraf": "2.6.2",
-                "ssri": "5.2.4",
-                "unique-filename": "1.1.0",
-                "y18n": "4.0.0"
+                "bluebird": "^3.5.1",
+                "chownr": "^1.0.1",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.1.11",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^2.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "ssri": "^5.2.4",
+                "unique-filename": "^1.1.0",
+                "y18n": "^4.0.0"
             }
         },
         "cache-base": {
@@ -3032,15 +3032,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -3063,8 +3063,8 @@
             "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2",
-                "upper-case": "1.1.3"
+                "no-case": "^2.2.0",
+                "upper-case": "^1.1.1"
             }
         },
         "camelcase": {
@@ -3079,8 +3079,8 @@
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "dev": true,
             "requires": {
-                "camelcase": "2.1.1",
-                "map-obj": "1.0.1"
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
             }
         },
         "caniuse-api": {
@@ -3089,10 +3089,10 @@
             "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000812",
-                "lodash.memoize": "4.1.2",
-                "lodash.uniq": "4.5.0"
+                "browserslist": "^1.3.6",
+                "caniuse-db": "^1.0.30000529",
+                "lodash.memoize": "^4.1.2",
+                "lodash.uniq": "^4.5.0"
             }
         },
         "caniuse-db": {
@@ -3125,8 +3125,8 @@
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "dev": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chalk": {
@@ -3135,9 +3135,9 @@
             "integrity": "sha512-LvixLAQ4MYhbf7hgL4o5PeK32gJKvVzDRiSNIApDofQvyhl8adgG2lJVXn4+ekQoK7HL9RF8lqxwerpe0x2pCw==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "4.5.0"
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
             }
         },
         "charenc": {
@@ -3152,22 +3152,22 @@
             "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-serializer": "0.1.0",
-                "entities": "1.1.1",
-                "htmlparser2": "3.9.2",
-                "lodash.assignin": "4.2.0",
-                "lodash.bind": "4.2.1",
-                "lodash.defaults": "4.2.0",
-                "lodash.filter": "4.6.0",
-                "lodash.flatten": "4.4.0",
-                "lodash.foreach": "4.5.0",
-                "lodash.map": "4.6.0",
-                "lodash.merge": "4.6.1",
-                "lodash.pick": "4.4.0",
-                "lodash.reduce": "4.6.0",
-                "lodash.reject": "4.6.0",
-                "lodash.some": "4.6.0"
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash.assignin": "^4.0.9",
+                "lodash.bind": "^4.1.4",
+                "lodash.defaults": "^4.0.1",
+                "lodash.filter": "^4.4.0",
+                "lodash.flatten": "^4.2.0",
+                "lodash.foreach": "^4.3.0",
+                "lodash.map": "^4.4.0",
+                "lodash.merge": "^4.4.0",
+                "lodash.pick": "^4.2.1",
+                "lodash.reduce": "^4.4.0",
+                "lodash.reject": "^4.4.0",
+                "lodash.some": "^4.4.0"
             },
             "dependencies": {
                 "domhandler": {
@@ -3200,15 +3200,15 @@
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "requires": {
-                "anymatch": "1.3.2",
-                "async-each": "1.0.1",
-                "fsevents": "1.1.3",
-                "glob-parent": "2.0.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "2.0.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0"
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
             }
         },
         "chownr": {
@@ -3223,8 +3223,8 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "circular-dependency-plugin": {
@@ -3239,9 +3239,9 @@
             "integrity": "sha512-6X9u1JBMak/9VbC0IZajEDvp19/PbjCanbRO3Z2xsluypQtbPPAGDvGGovLOWoUpXIvJH9vJExmzlqWvwItZxA==",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "glob": "7.1.2",
-                "resolve": "1.5.0"
+                "async": "^1.5.2",
+                "glob": "^7.0.0",
+                "resolve": "^1.1.6"
             },
             "dependencies": {
                 "async": {
@@ -3258,7 +3258,7 @@
             "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3"
+                "chalk": "^1.1.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -3273,11 +3273,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -3294,10 +3294,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -3306,7 +3306,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -3315,7 +3315,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -3324,7 +3324,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -3335,7 +3335,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -3344,7 +3344,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -3355,9 +3355,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "isobject": {
@@ -3380,7 +3380,7 @@
             "integrity": "sha1-PfwsJWnV8DwUtB2HWtm8yuCcuJ4=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "0.5.x"
             },
             "dependencies": {
                 "source-map": {
@@ -3403,9 +3403,9 @@
             "integrity": "sha1-Ng1taUbpmnof7zleQrqStem1oWs=",
             "optional": true,
             "requires": {
-                "good-listener": "1.2.2",
-                "select": "1.1.2",
-                "tiny-emitter": "2.0.2"
+                "good-listener": "^1.2.2",
+                "select": "^1.1.2",
+                "tiny-emitter": "^2.0.0"
             }
         },
         "cliui": {
@@ -3414,9 +3414,9 @@
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
             }
         },
         "clone": {
@@ -3431,10 +3431,10 @@
             "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "is-plain-object": "2.0.4",
-                "kind-of": "6.0.2",
-                "shallow-clone": "1.0.0"
+                "for-own": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.0",
+                "shallow-clone": "^1.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -3443,7 +3443,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 },
                 "kind-of": {
@@ -3466,7 +3466,7 @@
             "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.1.2"
             }
         },
         "code-point-at": {
@@ -3481,8 +3481,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color": {
@@ -3491,9 +3491,9 @@
             "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
             "dev": true,
             "requires": {
-                "clone": "1.0.3",
-                "color-convert": "1.9.1",
-                "color-string": "0.3.0"
+                "clone": "^1.0.2",
+                "color-convert": "^1.3.0",
+                "color-string": "^0.3.0"
             }
         },
         "color-convert": {
@@ -3502,7 +3502,7 @@
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -3517,7 +3517,7 @@
             "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.0.0"
             }
         },
         "colormin": {
@@ -3526,9 +3526,9 @@
             "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
             "dev": true,
             "requires": {
-                "color": "0.11.4",
+                "color": "^0.11.0",
                 "css-color-names": "0.0.4",
-                "has": "1.0.1"
+                "has": "^1.0.1"
             }
         },
         "colors": {
@@ -3543,7 +3543,7 @@
             "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.5"
+                "lodash": "^4.5.0"
             }
         },
         "combined-stream": {
@@ -3552,7 +3552,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -3573,7 +3573,7 @@
             "integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.26.0"
             }
         },
         "commondir": {
@@ -3606,10 +3606,10 @@
             "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "crc32-stream": "2.0.0",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.5"
+                "buffer-crc32": "^0.2.1",
+                "crc32-stream": "^2.0.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "compressible": {
@@ -3618,22 +3618,22 @@
             "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
             "dev": true,
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": ">= 1.33.0 < 2"
             }
         },
         "compression": {
             "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+            "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
             "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.4",
                 "bytes": "3.0.0",
-                "compressible": "2.0.13",
+                "compressible": "~2.0.13",
                 "debug": "2.6.9",
-                "on-headers": "1.0.1",
+                "on-headers": "~1.0.1",
                 "safe-buffer": "5.1.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             }
         },
         "concat-map": {
@@ -3647,9 +3647,9 @@
             "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "configstore": {
@@ -3658,12 +3658,12 @@
             "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
             "dev": true,
             "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.2.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.3.0",
-                "xdg-basedir": "3.0.0"
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "connect": {
@@ -3674,7 +3674,7 @@
             "requires": {
                 "debug": "2.6.9",
                 "finalhandler": "1.1.0",
-                "parseurl": "1.3.2",
+                "parseurl": "~1.3.2",
                 "utils-merge": "1.0.1"
             }
         },
@@ -3690,7 +3690,7 @@
             "integrity": "sha1-TZmZeKHSC7RgjnzUNNdBZSJVF0s=",
             "dev": true,
             "requires": {
-                "moment": "2.21.0"
+                "moment": "*"
             }
         },
         "console-browserify": {
@@ -3699,7 +3699,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "0.1.4"
+                "date-now": "^0.1.4"
             }
         },
         "console-control-strings": {
@@ -3750,12 +3750,12 @@
             "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
             }
         },
         "copy-descriptor": {
@@ -3770,14 +3770,14 @@
             "integrity": "sha512-ROQ85fWKuhJfUkBTdHvfV+Zv6Ltm3G/vPVFdLPFwzWzd9RUY1yLw3rt6FmKK2PaeNQCNvmwgFhuarkjuV4PVDQ==",
             "dev": true,
             "requires": {
-                "cacache": "10.0.4",
-                "find-cache-dir": "1.0.0",
-                "globby": "7.1.1",
-                "is-glob": "4.0.0",
-                "loader-utils": "1.1.0",
-                "minimatch": "3.0.4",
-                "p-limit": "1.2.0",
-                "serialize-javascript": "1.4.0"
+                "cacache": "^10.0.1",
+                "find-cache-dir": "^1.0.0",
+                "globby": "^7.1.1",
+                "is-glob": "^4.0.0",
+                "loader-utils": "^1.1.0",
+                "minimatch": "^3.0.4",
+                "p-limit": "^1.0.0",
+                "serialize-javascript": "^1.4.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -3808,7 +3808,7 @@
             "integrity": "sha512-sA2/4+/PZ/KV6CKgjrVrrUVBKCkdDO02CUlQ0YKTQoYUwPYNOtOAcWlbYhd5v/1JqYaA6oZ4sDlOU4ppVw6Wbg==",
             "dev": true,
             "requires": {
-                "chalk": "2.2.2"
+                "chalk": "^2.0.0"
             }
         },
         "core-util-is": {
@@ -3822,13 +3822,13 @@
             "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
             "dev": true,
             "requires": {
-                "is-directory": "0.3.1",
-                "js-yaml": "3.7.0",
-                "minimist": "1.2.0",
-                "object-assign": "4.1.1",
-                "os-homedir": "1.0.2",
-                "parse-json": "2.2.0",
-                "require-from-string": "1.2.1"
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.4.3",
+                "minimist": "^1.2.0",
+                "object-assign": "^4.1.0",
+                "os-homedir": "^1.0.1",
+                "parse-json": "^2.2.0",
+                "require-from-string": "^1.1.0"
             }
         },
         "cp-file": {
@@ -3837,13 +3837,13 @@
             "integrity": "sha1-b4NhYlRiTwrViqSqjQdvAmvn4Yg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "nested-error-stacks": "1.0.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "readable-stream": "2.3.5"
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "nested-error-stacks": "^1.0.1",
+                "object-assign": "^4.0.1",
+                "pify": "^2.3.0",
+                "pinkie-promise": "^2.0.0",
+                "readable-stream": "^2.1.4"
             },
             "dependencies": {
                 "pify": {
@@ -3860,17 +3860,17 @@
             "integrity": "sha1-GFvgGFEdhycN7czCkxceN2VauI8=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "chokidar": "1.7.0",
-                "duplexer": "0.1.1",
-                "glob": "7.1.2",
-                "glob2base": "0.0.12",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "resolve": "1.5.0",
-                "safe-buffer": "5.1.1",
-                "shell-quote": "1.6.1",
-                "subarg": "1.0.0"
+                "babel-runtime": "^6.9.2",
+                "chokidar": "^1.6.0",
+                "duplexer": "^0.1.1",
+                "glob": "^7.0.5",
+                "glob2base": "^0.0.12",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.1",
+                "resolve": "^1.1.7",
+                "safe-buffer": "^5.0.1",
+                "shell-quote": "^1.6.1",
+                "subarg": "^1.0.0"
             }
         },
         "cpy": {
@@ -3879,12 +3879,12 @@
             "integrity": "sha1-tnJn66LzlgugalphrJQDNCKDNCQ=",
             "dev": true,
             "requires": {
-                "cp-file": "3.2.0",
-                "globby": "4.1.0",
-                "meow": "3.7.0",
-                "nested-error-stacks": "1.0.2",
-                "object-assign": "4.1.1",
-                "pinkie-promise": "2.0.1"
+                "cp-file": "^3.1.0",
+                "globby": "^4.0.0",
+                "meow": "^3.6.0",
+                "nested-error-stacks": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -3893,11 +3893,11 @@
                     "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "globby": {
@@ -3906,12 +3906,12 @@
                     "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "arrify": "1.0.1",
-                        "glob": "6.0.4",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "arrify": "^1.0.0",
+                        "glob": "^6.0.1",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -3928,8 +3928,8 @@
             "integrity": "sha1-Z/taSi3sKMqKv/N13kuecfanVhw=",
             "dev": true,
             "requires": {
-                "cpy": "4.0.1",
-                "meow": "3.7.0"
+                "cpy": "^4.0.0",
+                "meow": "^3.6.0"
             }
         },
         "crc": {
@@ -3944,8 +3944,8 @@
             "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
             "dev": true,
             "requires": {
-                "crc": "3.5.0",
-                "readable-stream": "2.3.5"
+                "crc": "^3.4.4",
+                "readable-stream": "^2.0.0"
             }
         },
         "create-ecdh": {
@@ -3954,8 +3954,8 @@
             "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "elliptic": "6.4.0"
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.0.0"
             }
         },
         "create-error-class": {
@@ -3964,7 +3964,7 @@
             "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
             "dev": true,
             "requires": {
-                "capture-stack-trace": "1.0.0"
+                "capture-stack-trace": "^1.0.0"
             }
         },
         "create-hash": {
@@ -3973,10 +3973,10 @@
             "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "sha.js": "2.4.10"
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "sha.js": "^2.4.0"
             }
         },
         "create-hmac": {
@@ -3985,12 +3985,12 @@
             "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.1.3",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
-                "sha.js": "2.4.10"
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "cross-spawn": {
@@ -3999,8 +3999,8 @@
             "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.1",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
             }
         },
         "crypt": {
@@ -4015,7 +4015,7 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "crypto-browserify": {
@@ -4024,17 +4024,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "1.0.0",
-                "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.0",
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "diffie-hellman": "5.0.2",
-                "inherits": "2.0.3",
-                "pbkdf2": "3.0.14",
-                "public-encrypt": "4.0.0",
-                "randombytes": "2.0.6",
-                "randomfill": "1.0.4"
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
             }
         },
         "crypto-random-string": {
@@ -4055,20 +4055,20 @@
             "integrity": "sha512-X1IJteKnW9Llmrd+lJ0f7QZHh9Arf+11S7iRcoT2+riig3BK0QaCaOtubAulMK6Itbo08W6d3l8sW21r+Jhp5Q==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "css-selector-tokenizer": "0.7.0",
-                "cssnano": "3.10.0",
-                "icss-utils": "2.1.0",
-                "loader-utils": "1.1.0",
-                "lodash.camelcase": "4.3.0",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-modules-extract-imports": "1.2.0",
-                "postcss-modules-local-by-default": "1.2.0",
-                "postcss-modules-scope": "1.1.0",
-                "postcss-modules-values": "1.3.0",
-                "postcss-value-parser": "3.3.0",
-                "source-list-map": "2.0.0"
+                "babel-code-frame": "^6.26.0",
+                "css-selector-tokenizer": "^0.7.0",
+                "cssnano": "^3.10.0",
+                "icss-utils": "^2.1.0",
+                "loader-utils": "^1.0.2",
+                "lodash.camelcase": "^4.3.0",
+                "object-assign": "^4.1.1",
+                "postcss": "^5.0.6",
+                "postcss-modules-extract-imports": "^1.2.0",
+                "postcss-modules-local-by-default": "^1.2.0",
+                "postcss-modules-scope": "^1.1.0",
+                "postcss-modules-values": "^1.3.0",
+                "postcss-value-parser": "^3.3.0",
+                "source-list-map": "^2.0.0"
             }
         },
         "css-parse": {
@@ -4083,10 +4083,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "~1.0.1"
             }
         },
         "css-selector-tokenizer": {
@@ -4095,9 +4095,9 @@
             "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
             "dev": true,
             "requires": {
-                "cssesc": "0.1.0",
-                "fastparse": "1.1.1",
-                "regexpu-core": "1.0.0"
+                "cssesc": "^0.1.0",
+                "fastparse": "^1.1.1",
+                "regexpu-core": "^1.0.0"
             }
         },
         "css-what": {
@@ -4118,38 +4118,38 @@
             "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
             "dev": true,
             "requires": {
-                "autoprefixer": "6.7.7",
-                "decamelize": "1.2.0",
-                "defined": "1.0.0",
-                "has": "1.0.1",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-calc": "5.3.1",
-                "postcss-colormin": "2.2.2",
-                "postcss-convert-values": "2.6.1",
-                "postcss-discard-comments": "2.0.4",
-                "postcss-discard-duplicates": "2.1.0",
-                "postcss-discard-empty": "2.1.0",
-                "postcss-discard-overridden": "0.1.1",
-                "postcss-discard-unused": "2.2.3",
-                "postcss-filter-plugins": "2.0.2",
-                "postcss-merge-idents": "2.1.7",
-                "postcss-merge-longhand": "2.0.2",
-                "postcss-merge-rules": "2.1.2",
-                "postcss-minify-font-values": "1.0.5",
-                "postcss-minify-gradients": "1.0.5",
-                "postcss-minify-params": "1.2.2",
-                "postcss-minify-selectors": "2.1.1",
-                "postcss-normalize-charset": "1.1.1",
-                "postcss-normalize-url": "3.0.8",
-                "postcss-ordered-values": "2.2.3",
-                "postcss-reduce-idents": "2.4.0",
-                "postcss-reduce-initial": "1.0.1",
-                "postcss-reduce-transforms": "1.0.4",
-                "postcss-svgo": "2.1.6",
-                "postcss-unique-selectors": "2.0.2",
-                "postcss-value-parser": "3.3.0",
-                "postcss-zindex": "2.2.0"
+                "autoprefixer": "^6.3.1",
+                "decamelize": "^1.1.2",
+                "defined": "^1.0.0",
+                "has": "^1.0.1",
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.14",
+                "postcss-calc": "^5.2.0",
+                "postcss-colormin": "^2.1.8",
+                "postcss-convert-values": "^2.3.4",
+                "postcss-discard-comments": "^2.0.4",
+                "postcss-discard-duplicates": "^2.0.1",
+                "postcss-discard-empty": "^2.0.1",
+                "postcss-discard-overridden": "^0.1.1",
+                "postcss-discard-unused": "^2.2.1",
+                "postcss-filter-plugins": "^2.0.0",
+                "postcss-merge-idents": "^2.1.5",
+                "postcss-merge-longhand": "^2.0.1",
+                "postcss-merge-rules": "^2.0.3",
+                "postcss-minify-font-values": "^1.0.2",
+                "postcss-minify-gradients": "^1.0.1",
+                "postcss-minify-params": "^1.0.4",
+                "postcss-minify-selectors": "^2.0.4",
+                "postcss-normalize-charset": "^1.1.0",
+                "postcss-normalize-url": "^3.0.7",
+                "postcss-ordered-values": "^2.1.0",
+                "postcss-reduce-idents": "^2.2.2",
+                "postcss-reduce-initial": "^1.0.0",
+                "postcss-reduce-transforms": "^1.0.3",
+                "postcss-svgo": "^2.1.1",
+                "postcss-unique-selectors": "^2.0.2",
+                "postcss-value-parser": "^3.2.3",
+                "postcss-zindex": "^2.0.1"
             }
         },
         "csso": {
@@ -4158,8 +4158,8 @@
             "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
             "dev": true,
             "requires": {
-                "clap": "1.2.3",
-                "source-map": "0.5.7"
+                "clap": "^1.0.9",
+                "source-map": "^0.5.3"
             },
             "dependencies": {
                 "source-map": {
@@ -4182,7 +4182,7 @@
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "dev": true,
             "requires": {
-                "array-find-index": "1.0.2"
+                "array-find-index": "^1.0.1"
             }
         },
         "custom-event": {
@@ -4209,7 +4209,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.39"
+                "es5-ext": "^0.10.9"
             }
         },
         "dashdash": {
@@ -4218,7 +4218,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -4274,7 +4274,7 @@
             "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
             "dev": true,
             "requires": {
-                "strip-bom": "2.0.0"
+                "strip-bom": "^2.0.0"
             }
         },
         "define-properties": {
@@ -4283,8 +4283,8 @@
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
+                "foreach": "^2.0.5",
+                "object-keys": "^1.0.8"
             }
         },
         "define-property": {
@@ -4293,8 +4293,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -4317,12 +4317,12 @@
             "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "6.1.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.0",
-                "p-map": "1.2.0",
-                "pify": "3.0.0",
-                "rimraf": "2.6.2"
+                "globby": "^6.1.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "p-map": "^1.1.1",
+                "pify": "^3.0.0",
+                "rimraf": "^2.2.8"
             },
             "dependencies": {
                 "globby": {
@@ -4331,11 +4331,11 @@
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     },
                     "dependencies": {
                         "pify": {
@@ -4354,9 +4354,9 @@
             "integrity": "sha1-J1V9aaC335ncuqHjSgnmrGWR0sQ=",
             "dev": true,
             "requires": {
-                "del": "3.0.0",
-                "meow": "3.7.0",
-                "update-notifier": "2.3.0"
+                "del": "^3.0.0",
+                "meow": "^3.6.0",
+                "update-notifier": "^2.1.0"
             }
         },
         "delayed-stream": {
@@ -4395,8 +4395,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "destroy": {
@@ -4417,7 +4417,7 @@
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "detect-node": {
@@ -4438,8 +4438,8 @@
             "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
             "dev": true,
             "requires": {
-                "asap": "2.0.6",
-                "wrappy": "1.0.2"
+                "asap": "^2.0.0",
+                "wrappy": "1"
             }
         },
         "di": {
@@ -4460,9 +4460,9 @@
             "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "miller-rabin": "4.0.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
             }
         },
         "dir-glob": {
@@ -4471,8 +4471,8 @@
             "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "path-type": "3.0.0"
+                "arrify": "^1.0.1",
+                "path-type": "^3.0.0"
             }
         },
         "directory-encoder": {
@@ -4481,9 +4481,9 @@
             "integrity": "sha1-WbTiqk8lQi9sY7UntGL14tDdLFg=",
             "dev": true,
             "requires": {
-                "fs-extra": "0.23.1",
-                "handlebars": "1.3.0",
-                "img-stats": "0.5.2"
+                "fs-extra": "^0.23.1",
+                "handlebars": "^1.3.0",
+                "img-stats": "^0.5.2"
             },
             "dependencies": {
                 "async": {
@@ -4499,10 +4499,10 @@
                     "integrity": "sha1-ZhHbpq3yq43Jxp+rN83fiBgVfj0=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "2.4.0",
-                        "path-is-absolute": "1.0.1",
-                        "rimraf": "2.6.2"
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^2.1.0",
+                        "path-is-absolute": "^1.0.0",
+                        "rimraf": "^2.2.8"
                     }
                 },
                 "handlebars": {
@@ -4511,8 +4511,8 @@
                     "integrity": "sha1-npsTCpPjiUkTItl1zz7BgYw3zjQ=",
                     "dev": true,
                     "requires": {
-                        "optimist": "0.3.7",
-                        "uglify-js": "2.3.6"
+                        "optimist": "~0.3",
+                        "uglify-js": "~2.3"
                     }
                 },
                 "jsonfile": {
@@ -4521,7 +4521,7 @@
                     "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11"
+                        "graceful-fs": "^4.1.6"
                     }
                 },
                 "optimist": {
@@ -4530,7 +4530,7 @@
                     "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
                     "dev": true,
                     "requires": {
-                        "wordwrap": "0.0.2"
+                        "wordwrap": "~0.0.2"
                     }
                 },
                 "source-map": {
@@ -4540,7 +4540,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 },
                 "uglify-js": {
@@ -4550,9 +4550,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "async": "0.2.10",
-                        "optimist": "0.3.7",
-                        "source-map": "0.1.43"
+                        "async": "~0.2.6",
+                        "optimist": "~0.3.5",
+                        "source-map": "~0.1.7"
                     }
                 }
             }
@@ -4569,8 +4569,8 @@
             "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
             "dev": true,
             "requires": {
-                "ip": "1.1.5",
-                "safe-buffer": "5.1.1"
+                "ip": "^1.1.0",
+                "safe-buffer": "^5.0.1"
             }
         },
         "dns-txt": {
@@ -4579,7 +4579,7 @@
             "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
             "dev": true,
             "requires": {
-                "buffer-indexof": "1.1.1"
+                "buffer-indexof": "^1.0.0"
             }
         },
         "dom-converter": {
@@ -4588,7 +4588,7 @@
             "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
             "dev": true,
             "requires": {
-                "utila": "0.3.3"
+                "utila": "~0.3"
             },
             "dependencies": {
                 "utila": {
@@ -4605,10 +4605,10 @@
             "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
             "dev": true,
             "requires": {
-                "custom-event": "1.0.1",
-                "ent": "2.2.0",
-                "extend": "3.0.1",
-                "void-elements": "2.0.1"
+                "custom-event": "~1.0.0",
+                "ent": "~2.2.0",
+                "extend": "^3.0.0",
+                "void-elements": "^2.0.0"
             }
         },
         "dom-serializer": {
@@ -4617,8 +4617,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -4647,7 +4647,7 @@
             "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -4656,8 +4656,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "dot-prop": {
@@ -4666,7 +4666,7 @@
             "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "duplexer": {
@@ -4687,10 +4687,10 @@
             "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "easy-extender": {
@@ -4699,7 +4699,7 @@
             "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
             "dev": true,
             "requires": {
-                "lodash": "3.10.1"
+                "lodash": "^3.10.1"
             },
             "dependencies": {
                 "lodash": {
@@ -4716,7 +4716,7 @@
             "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
             "dev": true,
             "requires": {
-                "tfunk": "3.1.0"
+                "tfunk": "^3.0.1"
             }
         },
         "ecc-jsbn": {
@@ -4726,7 +4726,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "ee-first": {
@@ -4753,13 +4753,13 @@
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0",
-                "hash.js": "1.1.3",
-                "hmac-drbg": "1.0.1",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0",
-                "minimalistic-crypto-utils": "1.0.1"
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
             }
         },
         "ember-cli-string-utils": {
@@ -4792,7 +4792,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "engine.io": {
@@ -4815,7 +4815,7 @@
                     "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
                     "dev": true,
                     "requires": {
-                        "mime-types": "2.1.18",
+                        "mime-types": "~2.1.11",
                         "negotiator": "0.6.1"
                     }
                 },
@@ -4893,10 +4893,10 @@
             "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "memory-fs": "0.4.1",
-                "object-assign": "4.1.1",
-                "tapable": "0.2.8"
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.4.0",
+                "object-assign": "^4.0.1",
+                "tapable": "^0.2.7"
             }
         },
         "ent": {
@@ -4917,7 +4917,7 @@
             "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
             "dev": true,
             "requires": {
-                "prr": "1.0.1"
+                "prr": "~1.0.1"
             }
         },
         "error-ex": {
@@ -4926,7 +4926,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
@@ -4935,11 +4935,11 @@
             "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "1.1.1",
-                "function-bind": "1.1.1",
-                "has": "1.0.1",
-                "is-callable": "1.1.3",
-                "is-regex": "1.0.4"
+                "es-to-primitive": "^1.1.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1",
+                "is-callable": "^1.1.3",
+                "is-regex": "^1.0.4"
             }
         },
         "es-to-primitive": {
@@ -4948,9 +4948,9 @@
             "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
             "dev": true,
             "requires": {
-                "is-callable": "1.1.3",
-                "is-date-object": "1.0.1",
-                "is-symbol": "1.0.1"
+                "is-callable": "^1.1.1",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.1"
             }
         },
         "es5-ext": {
@@ -4959,8 +4959,8 @@
             "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1"
             }
         },
         "es6-iterator": {
@@ -4969,9 +4969,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.39",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
             }
         },
         "es6-map": {
@@ -4980,12 +4980,12 @@
             "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.39",
-                "es6-iterator": "2.0.3",
-                "es6-set": "0.1.5",
-                "es6-symbol": "3.1.1",
-                "event-emitter": "0.3.5"
+                "d": "1",
+                "es5-ext": "~0.10.14",
+                "es6-iterator": "~2.0.1",
+                "es6-set": "~0.1.5",
+                "es6-symbol": "~3.1.1",
+                "event-emitter": "~0.3.5"
             }
         },
         "es6-promise": {
@@ -5000,11 +5000,11 @@
             "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.39",
-                "es6-iterator": "2.0.3",
+                "d": "1",
+                "es5-ext": "~0.10.14",
+                "es6-iterator": "~2.0.1",
                 "es6-symbol": "3.1.1",
-                "event-emitter": "0.3.5"
+                "event-emitter": "~0.3.5"
             }
         },
         "es6-shim": {
@@ -5019,8 +5019,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.39"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "es6-templates": {
@@ -5029,8 +5029,8 @@
             "integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
             "dev": true,
             "requires": {
-                "recast": "0.11.23",
-                "through": "2.3.8"
+                "recast": "~0.11.12",
+                "through": "~2.3.6"
             }
         },
         "es6-weak-map": {
@@ -5039,10 +5039,10 @@
             "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.39",
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.14",
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-html": {
@@ -5063,10 +5063,10 @@
             "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
             "dev": true,
             "requires": {
-                "es6-map": "0.1.5",
-                "es6-weak-map": "2.0.2",
-                "esrecurse": "4.2.1",
-                "estraverse": "4.2.0"
+                "es6-map": "^0.1.3",
+                "es6-weak-map": "^2.0.1",
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
         },
         "esprima": {
@@ -5081,7 +5081,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.1.0"
             }
         },
         "estraverse": {
@@ -5114,23 +5114,23 @@
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.39"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "event-stream": {
             "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "eventemitter3": {
@@ -5151,7 +5151,7 @@
             "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
             "dev": true,
             "requires": {
-                "original": "1.0.0"
+                "original": ">=0.0.5"
             }
         },
         "evp_bytestokey": {
@@ -5160,8 +5160,8 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "1.3.4",
-                "safe-buffer": "5.1.1"
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
             }
         },
         "execa": {
@@ -5170,13 +5170,13 @@
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "dev": true,
             "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -5185,9 +5185,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "4.1.1",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.0"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 }
             }
@@ -5198,9 +5198,9 @@
             "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
             "dev": true,
             "requires": {
-                "array-slice": "0.2.3",
-                "array-unique": "0.2.1",
-                "braces": "0.1.5"
+                "array-slice": "^0.2.3",
+                "array-unique": "^0.2.1",
+                "braces": "^0.1.2"
             },
             "dependencies": {
                 "braces": {
@@ -5209,7 +5209,7 @@
                     "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "0.1.1"
+                        "expand-range": "^0.1.0"
                     }
                 },
                 "expand-range": {
@@ -5218,8 +5218,8 @@
                     "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
                     "dev": true,
                     "requires": {
-                        "is-number": "0.1.1",
-                        "repeat-string": "0.2.2"
+                        "is-number": "^0.1.1",
+                        "repeat-string": "^0.2.2"
                     }
                 },
                 "is-number": {
@@ -5241,7 +5241,7 @@
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -5249,7 +5249,7 @@
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
             }
         },
         "exports-loader": {
@@ -5258,8 +5258,8 @@
             "integrity": "sha1-1w/GEhl1s1/BKDDPUnVL4nQPyIY=",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "source-map": "0.5.7"
+                "loader-utils": "^1.0.2",
+                "source-map": "0.5.x"
             },
             "dependencies": {
                 "source-map": {
@@ -5276,36 +5276,36 @@
             "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.4",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.2",
                 "content-disposition": "0.5.2",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.1",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "finalhandler": "1.1.0",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "1.1.2",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.3",
+                "proxy-addr": "~2.0.2",
                 "qs": "6.5.1",
-                "range-parser": "1.2.0",
+                "range-parser": "~1.2.0",
                 "safe-buffer": "5.1.1",
                 "send": "0.16.1",
                 "serve-static": "1.13.1",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.3.1",
-                "type-is": "1.6.16",
+                "statuses": "~1.3.1",
+                "type-is": "~1.6.15",
                 "utils-merge": "1.0.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             },
             "dependencies": {
                 "array-flatten": {
@@ -5334,8 +5334,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -5344,7 +5344,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -5354,7 +5354,7 @@
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "extract-text-webpack-plugin": {
@@ -5363,10 +5363,10 @@
             "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
             "dev": true,
             "requires": {
-                "async": "2.6.0",
-                "loader-utils": "1.1.0",
-                "schema-utils": "0.3.0",
-                "webpack-sources": "1.1.0"
+                "async": "^2.4.1",
+                "loader-utils": "^1.1.0",
+                "schema-utils": "^0.3.0",
+                "webpack-sources": "^1.0.1"
             }
         },
         "extsprintf": {
@@ -5405,7 +5405,7 @@
             "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
             "dev": true,
             "requires": {
-                "websocket-driver": "0.7.0"
+                "websocket-driver": ">=0.5.1"
             }
         },
         "file-loader": {
@@ -5414,7 +5414,7 @@
             "integrity": "sha1-gVA0EZiR/GRB+1pkwRvJPCLd2EI=",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0"
+                "loader-utils": "^1.0.2"
             }
         },
         "filename-regex": {
@@ -5428,8 +5428,8 @@
             "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "minimatch": "3.0.4"
+                "glob": "^7.0.3",
+                "minimatch": "^3.0.3"
             }
         },
         "fill-range": {
@@ -5437,11 +5437,11 @@
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "finalhandler": {
@@ -5451,12 +5451,12 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
-                "statuses": "1.3.1",
-                "unpipe": "1.0.0"
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "statuses": "~1.3.1",
+                "unpipe": "~1.0.0"
             }
         },
         "find-cache-dir": {
@@ -5465,9 +5465,9 @@
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
-                "commondir": "1.0.1",
-                "make-dir": "1.2.0",
-                "pkg-dir": "2.0.0"
+                "commondir": "^1.0.1",
+                "make-dir": "^1.0.0",
+                "pkg-dir": "^2.0.0"
             }
         },
         "find-index": {
@@ -5488,7 +5488,7 @@
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
             }
         },
         "flatten": {
@@ -5503,8 +5503,8 @@
             "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
             }
         },
         "font-awesome": {
@@ -5522,7 +5522,7 @@
             "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "foreach": {
@@ -5543,9 +5543,9 @@
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "forwarded": {
@@ -5560,7 +5560,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "fresh": {
@@ -5581,8 +5581,8 @@
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
             }
         },
         "fs-access": {
@@ -5591,7 +5591,7 @@
             "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
             "dev": true,
             "requires": {
-                "null-check": "1.0.0"
+                "null-check": "^1.0.0"
             }
         },
         "fs-extra": {
@@ -5600,9 +5600,9 @@
             "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-write-stream-atomic": {
@@ -5611,10 +5611,10 @@
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "readable-stream": "2.3.5"
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
             }
         },
         "fs.realpath": {
@@ -5629,8 +5629,8 @@
             "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
             "optional": true,
             "requires": {
-                "nan": "2.9.2",
-                "node-pre-gyp": "0.6.39"
+                "nan": "^2.3.0",
+                "node-pre-gyp": "^0.6.39"
             },
             "dependencies": {
                 "abbrev": {
@@ -5643,8 +5643,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 },
                 "ansi-regex": {
@@ -5661,8 +5661,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "asn1": {
@@ -5699,28 +5699,28 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                     }
                 },
                 "block-stream": {
                     "version": "0.0.9",
                     "bundled": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "boom": {
                     "version": "2.10.1",
                     "bundled": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "brace-expansion": {
                     "version": "1.1.7",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -5746,7 +5746,7 @@
                     "version": "1.0.5",
                     "bundled": true,
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 },
                 "concat-map": {
@@ -5765,7 +5765,7 @@
                     "version": "2.0.5",
                     "bundled": true,
                     "requires": {
-                        "boom": "2.10.1"
+                        "boom": "2.x.x"
                     }
                 },
                 "dashdash": {
@@ -5773,7 +5773,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -5815,7 +5815,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "extend": {
@@ -5837,9 +5837,9 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.15"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.5",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "fs.realpath": {
@@ -5850,10 +5850,10 @@
                     "version": "1.0.11",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
+                        "graceful-fs": "^4.1.2",
+                        "inherits": "~2.0.0",
+                        "mkdirp": ">=0.5 0",
+                        "rimraf": "2"
                     }
                 },
                 "fstream-ignore": {
@@ -5861,9 +5861,9 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
+                        "fstream": "^1.0.0",
+                        "inherits": "2",
+                        "minimatch": "^3.0.0"
                     }
                 },
                 "gauge": {
@@ -5871,14 +5871,14 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.1.1",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "getpass": {
@@ -5886,7 +5886,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -5900,12 +5900,12 @@
                     "version": "7.1.2",
                     "bundled": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "graceful-fs": {
@@ -5922,8 +5922,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
+                        "ajv": "^4.9.1",
+                        "har-schema": "^1.0.5"
                     }
                 },
                 "has-unicode": {
@@ -5935,10 +5935,10 @@
                     "version": "3.1.3",
                     "bundled": true,
                     "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
+                        "boom": "2.x.x",
+                        "cryptiles": "2.x.x",
+                        "hoek": "2.x.x",
+                        "sntp": "1.x.x"
                     }
                 },
                 "hoek": {
@@ -5950,17 +5950,17 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
+                        "assert-plus": "^0.2.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -5976,7 +5976,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "is-typedarray": {
@@ -5998,7 +5998,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "jsbn": {
@@ -6016,7 +6016,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "jsonify": "0.0.0"
+                        "jsonify": "~0.0.0"
                     }
                 },
                 "json-stringify-safe": {
@@ -6055,14 +6055,14 @@
                     "version": "2.1.15",
                     "bundled": true,
                     "requires": {
-                        "mime-db": "1.27.0"
+                        "mime-db": "~1.27.0"
                     }
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "1.1.7"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -6086,17 +6086,17 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.2",
+                        "detect-libc": "^1.0.2",
                         "hawk": "3.1.3",
-                        "mkdirp": "0.5.1",
-                        "nopt": "4.0.1",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
+                        "mkdirp": "^0.5.1",
+                        "nopt": "^4.0.1",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
                         "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "tar-pack": "3.4.0"
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^2.2.1",
+                        "tar-pack": "^3.4.0"
                     }
                 },
                 "nopt": {
@@ -6104,8 +6104,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npmlog": {
@@ -6113,10 +6113,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -6137,7 +6137,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -6155,8 +6155,8 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -6187,10 +6187,10 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "~0.4.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -6204,13 +6204,13 @@
                     "version": "2.2.9",
                     "bundled": true,
                     "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
-                        "util-deprecate": "1.0.2"
+                        "buffer-shims": "~1.0.0",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~1.0.0",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "request": {
@@ -6218,35 +6218,35 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~4.2.1",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "performance-now": "^0.2.0",
+                        "qs": "~6.4.0",
+                        "safe-buffer": "^5.0.1",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "rimraf": {
                     "version": "2.6.1",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -6272,7 +6272,7 @@
                     "version": "1.0.9",
                     "bundled": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "sshpk": {
@@ -6280,15 +6280,15 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jodid25519": "^1.0.0",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.14.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -6302,16 +6302,16 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "stringstream": {
@@ -6323,7 +6323,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -6335,9 +6335,9 @@
                     "version": "2.2.1",
                     "bundled": true,
                     "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
+                        "block-stream": "*",
+                        "fstream": "^1.0.2",
+                        "inherits": "2"
                     }
                 },
                 "tar-pack": {
@@ -6345,14 +6345,14 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
+                        "debug": "^2.2.0",
+                        "fstream": "^1.0.10",
+                        "fstream-ignore": "^1.0.5",
+                        "once": "^1.3.3",
+                        "readable-stream": "^2.1.4",
+                        "rimraf": "^2.5.1",
+                        "tar": "^2.2.1",
+                        "uid-number": "^0.0.6"
                     }
                 },
                 "tough-cookie": {
@@ -6360,7 +6360,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
@@ -6368,7 +6368,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "tweetnacl": {
@@ -6403,7 +6403,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -6418,10 +6418,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "function-bind": {
@@ -6436,14 +6436,14 @@
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
             }
         },
         "gaze": {
@@ -6452,7 +6452,7 @@
             "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
             "dev": true,
             "requires": {
-                "globule": "1.2.0"
+                "globule": "^1.0.0"
             }
         },
         "generate-function": {
@@ -6467,7 +6467,7 @@
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
             "dev": true,
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "get-caller-file": {
@@ -6500,7 +6500,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6517,12 +6517,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -6530,8 +6530,8 @@
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "glob-parent": {
@@ -6539,7 +6539,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
             }
         },
         "glob2base": {
@@ -6548,7 +6548,7 @@
             "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
             "dev": true,
             "requires": {
-                "find-index": "0.1.1"
+                "find-index": "^0.1.1"
             }
         },
         "global-dirs": {
@@ -6557,7 +6557,7 @@
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
             "dev": true,
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.4"
             }
         },
         "globals": {
@@ -6572,12 +6572,12 @@
             "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "dir-glob": "2.0.0",
-                "glob": "7.1.2",
-                "ignore": "3.3.7",
-                "pify": "3.0.0",
-                "slash": "1.0.0"
+                "array-union": "^1.0.1",
+                "dir-glob": "^2.0.0",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.5",
+                "pify": "^3.0.0",
+                "slash": "^1.0.0"
             }
         },
         "globule": {
@@ -6586,9 +6586,9 @@
             "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "lodash": "4.17.5",
-                "minimatch": "3.0.4"
+                "glob": "~7.1.1",
+                "lodash": "~4.17.4",
+                "minimatch": "~3.0.2"
             }
         },
         "good-listener": {
@@ -6597,7 +6597,7 @@
             "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
             "optional": true,
             "requires": {
-                "delegate": "3.2.0"
+                "delegate": "^3.1.2"
             }
         },
         "got": {
@@ -6606,17 +6606,17 @@
             "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
             "dev": true,
             "requires": {
-                "create-error-class": "3.0.2",
-                "duplexer3": "0.1.4",
-                "get-stream": "3.0.0",
-                "is-redirect": "1.0.0",
-                "is-retry-allowed": "1.1.0",
-                "is-stream": "1.1.0",
-                "lowercase-keys": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "timed-out": "4.0.1",
-                "unzip-response": "2.0.1",
-                "url-parse-lax": "1.0.0"
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -6636,10 +6636,10 @@
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
             },
             "dependencies": {
                 "async": {
@@ -6662,8 +6662,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                     }
                 },
@@ -6673,7 +6673,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 },
                 "uglify-js": {
@@ -6683,9 +6683,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
                     },
                     "dependencies": {
                         "source-map": {
@@ -6704,9 +6704,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
+                        "camelcase": "^1.0.2",
+                        "cliui": "^2.1.0",
+                        "decamelize": "^1.0.0",
                         "window-size": "0.1.0"
                     }
                 }
@@ -6724,8 +6724,8 @@
             "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
             "dev": true,
             "requires": {
-                "ajv": "4.11.8",
-                "har-schema": "1.0.5"
+                "ajv": "^4.9.1",
+                "har-schema": "^1.0.5"
             },
             "dependencies": {
                 "ajv": {
@@ -6734,8 +6734,8 @@
                     "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 }
             }
@@ -6746,7 +6746,7 @@
             "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.0.2"
             }
         },
         "has-ansi": {
@@ -6755,7 +6755,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-binary": {
@@ -6816,9 +6816,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -6835,8 +6835,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -6845,7 +6845,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6854,7 +6854,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6865,7 +6865,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -6876,7 +6876,7 @@
             "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "^2.0.1"
             }
         },
         "hash.js": {
@@ -6885,8 +6885,8 @@
             "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.0"
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "hawk": {
@@ -6895,10 +6895,10 @@
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -6913,9 +6913,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "1.1.3",
-                "minimalistic-assert": "1.0.0",
-                "minimalistic-crypto-utils": "1.0.1"
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "hoek": {
@@ -6930,7 +6930,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -6945,10 +6945,10 @@
             "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "obuf": "1.1.1",
-                "readable-stream": "2.3.5",
-                "wbuf": "1.7.2"
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
             }
         },
         "html-comment-regex": {
@@ -6969,11 +6969,11 @@
             "integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
             "dev": true,
             "requires": {
-                "es6-templates": "0.2.3",
-                "fastparse": "1.1.1",
-                "html-minifier": "3.5.10",
-                "loader-utils": "1.1.0",
-                "object-assign": "4.1.1"
+                "es6-templates": "^0.2.3",
+                "fastparse": "^1.1.1",
+                "html-minifier": "^3.5.8",
+                "loader-utils": "^1.1.0",
+                "object-assign": "^4.1.1"
             }
         },
         "html-minifier": {
@@ -6982,14 +6982,14 @@
             "integrity": "sha512-5c8iAyeIGAiuFhVjJ0qy1lgvyQxxuZgjeOuMnoK/wjEyy8DF3xKUnE9pO+6H7VMir976K6SGlZV8ZEmIOea/Zg==",
             "dev": true,
             "requires": {
-                "camel-case": "3.0.0",
-                "clean-css": "4.1.10",
-                "commander": "2.14.1",
-                "he": "1.1.1",
-                "ncname": "1.0.0",
-                "param-case": "2.1.1",
-                "relateurl": "0.2.7",
-                "uglify-js": "3.3.13"
+                "camel-case": "3.0.x",
+                "clean-css": "4.1.x",
+                "commander": "2.14.x",
+                "he": "1.1.x",
+                "ncname": "1.0.x",
+                "param-case": "2.1.x",
+                "relateurl": "0.2.x",
+                "uglify-js": "3.3.x"
             }
         },
         "html-webpack-plugin": {
@@ -6998,12 +6998,12 @@
             "integrity": "sha1-f5xCG36pHsRg9WUn1430hO51N9U=",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "html-minifier": "3.5.10",
-                "loader-utils": "0.2.17",
-                "lodash": "4.17.5",
-                "pretty-error": "2.1.1",
-                "toposort": "1.0.6"
+                "bluebird": "^3.4.7",
+                "html-minifier": "^3.2.3",
+                "loader-utils": "^0.2.16",
+                "lodash": "^4.17.3",
+                "pretty-error": "^2.0.2",
+                "toposort": "^1.0.0"
             },
             "dependencies": {
                 "loader-utils": {
@@ -7026,10 +7026,10 @@
             "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.1.0",
-                "domutils": "1.1.6",
-                "readable-stream": "1.0.34"
+                "domelementtype": "1",
+                "domhandler": "2.1",
+                "domutils": "1.1",
+                "readable-stream": "1.0"
             },
             "dependencies": {
                 "domutils": {
@@ -7038,7 +7038,7 @@
                     "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0"
+                        "domelementtype": "1"
                     }
                 },
                 "isarray": {
@@ -7053,10 +7053,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -7082,7 +7082,7 @@
                 "depd": "1.1.1",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.0.3",
-                "statuses": "1.3.1"
+                "statuses": ">= 1.3.1 < 2"
             },
             "dependencies": {
                 "depd": {
@@ -7111,8 +7111,8 @@
             "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
             "dev": true,
             "requires": {
-                "eventemitter3": "1.2.0",
-                "requires-port": "1.0.0"
+                "eventemitter3": "1.x.x",
+                "requires-port": "1.x.x"
             }
         },
         "http-proxy-middleware": {
@@ -7121,10 +7121,10 @@
             "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
             "dev": true,
             "requires": {
-                "http-proxy": "1.16.2",
-                "is-glob": "3.1.0",
-                "lodash": "4.17.5",
-                "micromatch": "2.3.11"
+                "http-proxy": "^1.16.2",
+                "is-glob": "^3.1.0",
+                "lodash": "^4.17.2",
+                "micromatch": "^2.3.11"
             },
             "dependencies": {
                 "is-extglob": {
@@ -7139,7 +7139,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -7150,9 +7150,9 @@
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "https-browserify": {
@@ -7167,9 +7167,9 @@
             "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
             "dev": true,
             "requires": {
-                "agent-base": "2.1.1",
-                "debug": "2.6.9",
-                "extend": "3.0.1"
+                "agent-base": "2",
+                "debug": "2",
+                "extend": "3"
             }
         },
         "i": {
@@ -7196,7 +7196,7 @@
             "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.19"
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "chalk": {
@@ -7205,9 +7205,9 @@
                     "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -7222,9 +7222,9 @@
                     "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.2.0"
                     }
                 },
                 "supports-color": {
@@ -7233,7 +7233,7 @@
                     "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -7269,7 +7269,7 @@
             "integrity": "sha1-wgNJbELy2esuWrgjL6dWurMsnis=",
             "dev": true,
             "requires": {
-                "xmldom": "0.1.27"
+                "xmldom": "^0.1.19"
             }
         },
         "immutable": {
@@ -7290,8 +7290,8 @@
             "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
             "dev": true,
             "requires": {
-                "pkg-dir": "2.0.0",
-                "resolve-cwd": "2.0.0"
+                "pkg-dir": "^2.0.0",
+                "resolve-cwd": "^2.0.0"
             }
         },
         "imurmurhash": {
@@ -7312,7 +7312,7 @@
             "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
             "dev": true,
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "indexes-of": {
@@ -7333,8 +7333,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -7360,7 +7360,7 @@
             "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
             "dev": true,
             "requires": {
-                "meow": "3.7.0"
+                "meow": "^3.3.0"
             }
         },
         "interpret": {
@@ -7375,7 +7375,7 @@
             "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
             "dev": true,
             "requires": {
-                "loose-envify": "1.3.1"
+                "loose-envify": "^1.0.0"
             }
         },
         "invert-kv": {
@@ -7408,7 +7408,7 @@
             "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -7430,7 +7430,7 @@
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -7444,7 +7444,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-callable": {
@@ -7459,7 +7459,7 @@
             "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -7482,9 +7482,9 @@
             "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -7511,7 +7511,7 @@
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -7530,7 +7530,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -7539,7 +7539,7 @@
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-glob": {
@@ -7547,7 +7547,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "is-installed-globally": {
@@ -7556,8 +7556,8 @@
             "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
             "dev": true,
             "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.1"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-module": {
@@ -7578,11 +7578,11 @@
             "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
             "dev": true,
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "is-my-ip-valid": "1.0.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "is-my-ip-valid": "^1.0.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-npm": {
@@ -7596,7 +7596,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-number-like": {
@@ -7605,7 +7605,7 @@
             "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
             "dev": true,
             "requires": {
-                "lodash.isfinite": "3.3.2"
+                "lodash.isfinite": "^3.3.2"
             }
         },
         "is-obj": {
@@ -7620,7 +7620,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -7643,7 +7643,7 @@
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -7652,7 +7652,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-obj": {
@@ -7667,7 +7667,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -7706,7 +7706,7 @@
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
-                "has": "1.0.1"
+                "has": "^1.0.1"
             }
         },
         "is-retry-allowed": {
@@ -7727,7 +7727,7 @@
             "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
             "dev": true,
             "requires": {
-                "html-comment-regex": "1.1.1"
+                "html-comment-regex": "^1.1.0"
             }
         },
         "is-symbol": {
@@ -7797,17 +7797,17 @@
             "integrity": "sha512-kH5YRdqdbs5hiH4/Rr1Q0cSAGgjh3jTtg8vu9NLebBAoK3adVO4jk81J+TYOkTr2+Q4NLeb1ACvmEt65iG/Vbw==",
             "dev": true,
             "requires": {
-                "async": "2.6.0",
-                "fileset": "2.0.3",
-                "istanbul-lib-coverage": "1.1.2",
-                "istanbul-lib-hook": "1.1.0",
-                "istanbul-lib-instrument": "1.9.2",
-                "istanbul-lib-report": "1.1.3",
-                "istanbul-lib-source-maps": "1.2.3",
-                "istanbul-reports": "1.1.4",
-                "js-yaml": "3.7.0",
-                "mkdirp": "0.5.1",
-                "once": "1.4.0"
+                "async": "^2.1.4",
+                "fileset": "^2.0.2",
+                "istanbul-lib-coverage": "^1.1.2",
+                "istanbul-lib-hook": "^1.1.0",
+                "istanbul-lib-instrument": "^1.9.2",
+                "istanbul-lib-report": "^1.1.3",
+                "istanbul-lib-source-maps": "^1.2.3",
+                "istanbul-reports": "^1.1.4",
+                "js-yaml": "^3.7.0",
+                "mkdirp": "^0.5.1",
+                "once": "^1.4.0"
             }
         },
         "istanbul-instrumenter-loader": {
@@ -7816,10 +7816,10 @@
             "integrity": "sha1-5UkpAKsLuoNe+oAkywC+mz7qJwA=",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.5.1",
-                "istanbul-lib-instrument": "1.9.2",
-                "loader-utils": "0.2.17",
-                "object-assign": "4.1.1"
+                "convert-source-map": "^1.3.0",
+                "istanbul-lib-instrument": "^1.1.3",
+                "loader-utils": "^0.2.16",
+                "object-assign": "^4.1.0"
             },
             "dependencies": {
                 "loader-utils": {
@@ -7828,10 +7828,10 @@
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1",
-                        "object-assign": "4.1.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0",
+                        "object-assign": "^4.0.1"
                     }
                 }
             }
@@ -7848,7 +7848,7 @@
             "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
             "dev": true,
             "requires": {
-                "append-transform": "0.4.0"
+                "append-transform": "^0.4.0"
             }
         },
         "istanbul-lib-instrument": {
@@ -7857,13 +7857,13 @@
             "integrity": "sha512-nz8t4HQ2206a/3AXi+NHFWEa844DMpPsgbcUteJbt1j8LX1xg56H9rOMnhvcvVvPbW60qAIyrSk44H8ZDqaSSA==",
             "dev": true,
             "requires": {
-                "babel-generator": "6.26.1",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "istanbul-lib-coverage": "1.1.2",
-                "semver": "5.5.0"
+                "babel-generator": "^6.18.0",
+                "babel-template": "^6.16.0",
+                "babel-traverse": "^6.18.0",
+                "babel-types": "^6.18.0",
+                "babylon": "^6.18.0",
+                "istanbul-lib-coverage": "^1.1.2",
+                "semver": "^5.3.0"
             }
         },
         "istanbul-lib-report": {
@@ -7872,10 +7872,10 @@
             "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "1.1.2",
-                "mkdirp": "0.5.1",
-                "path-parse": "1.0.5",
-                "supports-color": "3.2.3"
+                "istanbul-lib-coverage": "^1.1.2",
+                "mkdirp": "^0.5.1",
+                "path-parse": "^1.0.5",
+                "supports-color": "^3.1.2"
             },
             "dependencies": {
                 "has-flag": {
@@ -7901,11 +7901,11 @@
             "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "istanbul-lib-coverage": "1.1.2",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "source-map": "0.5.7"
+                "debug": "^3.1.0",
+                "istanbul-lib-coverage": "^1.1.2",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.6.1",
+                "source-map": "^0.5.3"
             },
             "dependencies": {
                 "debug": {
@@ -7931,7 +7931,7 @@
             "integrity": "sha512-DfSTVOTkuO+kRmbO8Gk650Wqm1WRGr6lrdi2EwDK1vxpS71vdlLd613EpzOKdIFioB5f/scJTjeWBnvd1FWejg==",
             "dev": true,
             "requires": {
-                "handlebars": "4.0.11"
+                "handlebars": "^4.0.3"
             }
         },
         "jasmine-core": {
@@ -7981,8 +7981,8 @@
             "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "2.7.3"
+                "argparse": "^1.0.7",
+                "esprima": "^2.6.0"
             }
         },
         "jsbn": {
@@ -8028,7 +8028,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -8055,7 +8055,7 @@
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
@@ -8096,33 +8096,33 @@
             "integrity": "sha512-k5pBjHDhmkdaUccnC7gE3mBzZjcxyxYsYVaqiL2G5AqlfLyBO5nw2VdNK+O16cveEPd/gIOWULH7gkiYYwVNHg==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "body-parser": "1.18.2",
-                "chokidar": "1.7.0",
-                "colors": "1.1.2",
-                "combine-lists": "1.0.1",
-                "connect": "3.6.6",
-                "core-js": "2.5.3",
-                "di": "0.0.1",
-                "dom-serialize": "2.2.1",
-                "expand-braces": "0.1.2",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "http-proxy": "1.16.2",
-                "isbinaryfile": "3.0.2",
-                "lodash": "3.10.1",
-                "log4js": "0.6.38",
-                "mime": "1.6.0",
-                "minimatch": "3.0.4",
-                "optimist": "0.6.1",
-                "qjobs": "1.2.0",
-                "range-parser": "1.2.0",
-                "rimraf": "2.6.2",
-                "safe-buffer": "5.1.1",
+                "bluebird": "^3.3.0",
+                "body-parser": "^1.16.1",
+                "chokidar": "^1.4.1",
+                "colors": "^1.1.0",
+                "combine-lists": "^1.0.0",
+                "connect": "^3.6.0",
+                "core-js": "^2.2.0",
+                "di": "^0.0.1",
+                "dom-serialize": "^2.2.0",
+                "expand-braces": "^0.1.1",
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.1.2",
+                "http-proxy": "^1.13.0",
+                "isbinaryfile": "^3.0.0",
+                "lodash": "^3.8.0",
+                "log4js": "^0.6.31",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.2",
+                "optimist": "^0.6.1",
+                "qjobs": "^1.1.4",
+                "range-parser": "^1.2.0",
+                "rimraf": "^2.6.0",
+                "safe-buffer": "^5.0.1",
                 "socket.io": "1.7.3",
-                "source-map": "0.5.7",
+                "source-map": "^0.5.3",
                 "tmp": "0.0.31",
-                "useragent": "2.3.0"
+                "useragent": "^2.1.12"
             },
             "dependencies": {
                 "lodash": {
@@ -8145,8 +8145,8 @@
             "integrity": "sha1-IWh5xorATY1RQOmWGboEtZr9Rs8=",
             "dev": true,
             "requires": {
-                "fs-access": "1.0.1",
-                "which": "1.3.0"
+                "fs-access": "^1.0.0",
+                "which": "^1.2.1"
             }
         },
         "karma-cli": {
@@ -8155,7 +8155,7 @@
             "integrity": "sha1-rmw8WKMTodALRRZMRVubhs4X+WA=",
             "dev": true,
             "requires": {
-                "resolve": "1.5.0"
+                "resolve": "^1.1.6"
             }
         },
         "karma-coverage-istanbul-reporter": {
@@ -8164,8 +8164,8 @@
             "integrity": "sha512-5og0toMjgLvsL9+TzGH4Rk1D0nr7pMIRJBg29xP4mHMKy/1KUJ12UzoqI6mBNCRFa4nDvZS2MRrN7p+RkZNWxQ==",
             "dev": true,
             "requires": {
-                "istanbul-api": "1.2.2",
-                "minimatch": "3.0.4"
+                "istanbul-api": "^1.1.14",
+                "minimatch": "^3.0.4"
             }
         },
         "karma-firefox-launcher": {
@@ -8186,7 +8186,7 @@
             "integrity": "sha1-SKjl7xiAdhfuK14zwRlMNbQ5Ukw=",
             "dev": true,
             "requires": {
-                "karma-jasmine": "1.1.1"
+                "karma-jasmine": "^1.0.2"
             }
         },
         "karma-jasmine-matchers": {
@@ -8204,9 +8204,9 @@
             "integrity": "sha1-FRIAlejtgZGG5HoLAS8810GJVWA=",
             "dev": true,
             "requires": {
-                "chalk": "2.2.2",
-                "log-symbols": "2.2.0",
-                "strip-ansi": "4.0.0"
+                "chalk": "^2.1.0",
+                "log-symbols": "^2.1.0",
+                "strip-ansi": "^4.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -8221,7 +8221,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -8238,10 +8238,10 @@
             "integrity": "sha512-lEhtGRGS+3Yw6JSx/vJY9iQyHNtTjcojrSwNzqNUOaDceKDu9dPZqA/kr69bUO9G2T6GKbu8AZgXqy94qo31Jg==",
             "dev": true,
             "requires": {
-                "q": "1.5.1",
-                "sauce-connect-launcher": "1.2.3",
-                "saucelabs": "1.4.0",
-                "wd": "1.5.0"
+                "q": "^1.5.0",
+                "sauce-connect-launcher": "^1.2.2",
+                "saucelabs": "^1.4.0",
+                "wd": "^1.4.0"
             }
         },
         "karma-source-map-support": {
@@ -8250,7 +8250,7 @@
             "integrity": "sha1-G/gee7SwiWJ6s1LsQXnhF8QGpUA=",
             "dev": true,
             "requires": {
-                "source-map-support": "0.4.18"
+                "source-map-support": "^0.4.1"
             },
             "dependencies": {
                 "source-map": {
@@ -8265,7 +8265,7 @@
                     "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7"
+                        "source-map": "^0.5.6"
                     }
                 }
             }
@@ -8276,7 +8276,7 @@
             "integrity": "sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.2"
             }
         },
         "karma-webpack": {
@@ -8285,12 +8285,12 @@
             "integrity": "sha512-2cyII34jfrAabbI2+4Rk4j95Nazl98FvZQhgSiqKUDarT317rxfv/EdzZ60CyATN4PQxJdO5ucR5bOOXkEVrXw==",
             "dev": true,
             "requires": {
-                "async": "2.6.0",
-                "babel-runtime": "6.26.0",
-                "loader-utils": "1.1.0",
-                "lodash": "4.17.5",
-                "source-map": "0.5.7",
-                "webpack-dev-middleware": "1.12.2"
+                "async": "^2.0.0",
+                "babel-runtime": "^6.0.0",
+                "loader-utils": "^1.0.0",
+                "lodash": "^4.0.0",
+                "source-map": "^0.5.6",
+                "webpack-dev-middleware": "^1.12.0"
             },
             "dependencies": {
                 "source-map": {
@@ -8312,7 +8312,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "last-call-webpack-plugin": {
@@ -8321,8 +8321,8 @@
             "integrity": "sha512-CZc+m2xZm51J8qSwdODeiiNeqh8CYkKEq6Rw8IkE4i/4yqf2cJhjQPsA6BtAV970ePRNhwEOXhy2U5xc5Jwh9Q==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.5",
-                "webpack-sources": "1.1.0"
+                "lodash": "^4.17.4",
+                "webpack-sources": "^1.0.1"
             }
         },
         "latest-version": {
@@ -8331,7 +8331,7 @@
             "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
             "dev": true,
             "requires": {
-                "package-json": "4.0.1"
+                "package-json": "^4.0.0"
             }
         },
         "lazy-cache": {
@@ -8346,7 +8346,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.5"
             }
         },
         "lcid": {
@@ -8355,7 +8355,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "less": {
@@ -8364,14 +8364,14 @@
             "integrity": "sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==",
             "dev": true,
             "requires": {
-                "errno": "0.1.7",
-                "graceful-fs": "4.1.11",
-                "image-size": "0.5.5",
-                "mime": "1.6.0",
-                "mkdirp": "0.5.1",
-                "promise": "7.3.1",
+                "errno": "^0.1.1",
+                "graceful-fs": "^4.1.2",
+                "image-size": "~0.5.0",
+                "mime": "^1.2.11",
+                "mkdirp": "^0.5.0",
+                "promise": "^7.1.1",
                 "request": "2.81.0",
-                "source-map": "0.5.7"
+                "source-map": "^0.5.3"
             },
             "dependencies": {
                 "source-map": {
@@ -8389,9 +8389,9 @@
             "integrity": "sha512-WPFY3NMJGJna8kIxtgSu6AVG7K6uRPdfE2J7vpQqFWMN/RkOosV09rOVUt3wghNClWH2Pg7YumD1dHiv1Thfug==",
             "dev": true,
             "requires": {
-                "clone": "2.1.1",
-                "loader-utils": "1.1.0",
-                "pify": "3.0.0"
+                "clone": "^2.1.1",
+                "loader-utils": "^1.1.0",
+                "pify": "^3.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -8408,7 +8408,7 @@
             "integrity": "sha512-+sie46vNe5L48N94LEzEvreJqAdi+N3x3mXUx+iujuAmftWdJUh68RSDPgWK3DRJuu50dwiyH7MdVAx95zfKQA==",
             "dev": true,
             "requires": {
-                "ejs": "2.5.7"
+                "ejs": "^2.5.7"
             }
         },
         "limiter": {
@@ -8423,10 +8423,10 @@
             "integrity": "sha1-W0zI9dX9SDYQVICrKsSKOg3isMg=",
             "dev": true,
             "requires": {
-                "browser-sync": "2.23.6",
-                "connect-history-api-fallback": "1.5.0",
+                "browser-sync": "^2.18.5",
+                "connect-history-api-fallback": "^1.2.0",
                 "connect-logger": "0.0.1",
-                "lodash": "4.17.5",
+                "lodash": "^4.11.1",
                 "minimist": "1.2.0"
             }
         },
@@ -8436,11 +8436,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -8463,9 +8463,9 @@
             "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
             "dev": true,
             "requires": {
-                "big.js": "3.2.0",
-                "emojis-list": "2.1.0",
-                "json5": "0.5.1"
+                "big.js": "^3.1.3",
+                "emojis-list": "^2.0.0",
+                "json5": "^0.5.0"
             }
         },
         "localtunnel": {
@@ -8513,12 +8513,12 @@
                     "integrity": "sha1-GquWYOrnnYuPZ1vK7qtu40ws9pw=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "os-locale": "1.4.0",
-                        "window-size": "0.1.4",
-                        "y18n": "3.2.1"
+                        "camelcase": "^1.2.1",
+                        "cliui": "^3.0.3",
+                        "decamelize": "^1.0.0",
+                        "os-locale": "^1.4.0",
+                        "window-size": "^0.1.2",
+                        "y18n": "^3.2.0"
                     }
                 }
             }
@@ -8529,8 +8529,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
@@ -8665,7 +8665,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "2.2.2"
+                "chalk": "^2.0.1"
             }
         },
         "log4js": {
@@ -8674,8 +8674,8 @@
             "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.0.34",
-                "semver": "4.3.6"
+                "readable-stream": "~1.0.2",
+                "semver": "~4.3.3"
             },
             "dependencies": {
                 "isarray": {
@@ -8690,10 +8690,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "semver": {
@@ -8728,7 +8728,7 @@
             "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
             "dev": true,
             "requires": {
-                "js-tokens": "3.0.2"
+                "js-tokens": "^3.0.0"
             }
         },
         "loud-rejection": {
@@ -8737,8 +8737,8 @@
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "dev": true,
             "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
             }
         },
         "lower-case": {
@@ -8759,8 +8759,8 @@
             "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "macaddress": {
@@ -8775,7 +8775,7 @@
             "integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
             "dev": true,
             "requires": {
-                "vlq": "0.2.3"
+                "vlq": "^0.2.1"
             }
         },
         "make-dir": {
@@ -8784,7 +8784,7 @@
             "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "make-error": {
@@ -8817,7 +8817,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "math-expression-evaluator": {
@@ -8832,9 +8832,9 @@
             "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
             "dev": true,
             "requires": {
-                "charenc": "0.0.2",
-                "crypt": "0.0.2",
-                "is-buffer": "1.1.6"
+                "charenc": "~0.0.1",
+                "crypt": "~0.0.1",
+                "is-buffer": "~1.1.1"
             }
         },
         "md5.js": {
@@ -8843,8 +8843,8 @@
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "dev": true,
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             },
             "dependencies": {
                 "hash-base": {
@@ -8853,8 +8853,8 @@
                     "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "safe-buffer": "5.1.1"
+                        "inherits": "^2.0.1",
+                        "safe-buffer": "^5.0.1"
                     }
                 }
             }
@@ -8871,7 +8871,7 @@
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "memory-fs": {
@@ -8880,8 +8880,8 @@
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "dev": true,
             "requires": {
-                "errno": "0.1.7",
-                "readable-stream": "2.3.5"
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
             }
         },
         "memorystream": {
@@ -8896,16 +8896,16 @@
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "dev": true,
             "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.4.0",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
             }
         },
         "merge-descriptors": {
@@ -8925,19 +8925,19 @@
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             }
         },
         "miller-rabin": {
@@ -8946,8 +8946,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0"
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
             }
         },
         "mime": {
@@ -8968,7 +8968,7 @@
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "dev": true,
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
             }
         },
         "mimic-fn": {
@@ -8994,7 +8994,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -9008,16 +9008,16 @@
             "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
             "dev": true,
             "requires": {
-                "concat-stream": "1.6.1",
-                "duplexify": "3.5.4",
-                "end-of-stream": "1.4.1",
-                "flush-write-stream": "1.0.2",
-                "from2": "2.3.0",
-                "parallel-transform": "1.1.0",
-                "pump": "2.0.1",
-                "pumpify": "1.4.0",
-                "stream-each": "1.2.2",
-                "through2": "2.0.3"
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^2.0.1",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
             }
         },
         "mixin-deep": {
@@ -9026,8 +9026,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -9036,7 +9036,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -9047,8 +9047,8 @@
             "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
             "dev": true,
             "requires": {
-                "for-in": "0.1.8",
-                "is-extendable": "0.1.1"
+                "for-in": "^0.1.3",
+                "is-extendable": "^0.1.1"
             },
             "dependencies": {
                 "for-in": {
@@ -9086,12 +9086,12 @@
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "copy-concurrently": "1.0.5",
-                "fs-write-stream-atomic": "1.0.10",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "copy-concurrently": "^1.0.0",
+                "fs-write-stream-atomic": "^1.0.8",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.3"
             }
         },
         "ms": {
@@ -9106,8 +9106,8 @@
             "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
             "dev": true,
             "requires": {
-                "dns-packet": "1.3.1",
-                "thunky": "1.0.2"
+                "dns-packet": "^1.3.1",
+                "thunky": "^1.0.2"
             }
         },
         "multicast-dns-service-types": {
@@ -9133,18 +9133,18 @@
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.1",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -9173,7 +9173,7 @@
             "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
             "dev": true,
             "requires": {
-                "xml-char-classes": "1.0.0"
+                "xml-char-classes": "^1.0.0"
             }
         },
         "ncp": {
@@ -9200,7 +9200,7 @@
             "integrity": "sha1-GfYZWRUZ8JZ2mlupqG5u7sgjw88=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.1"
             }
         },
         "ng-packagr": {
@@ -9209,31 +9209,31 @@
             "integrity": "sha512-IBrb/Q5QyRyvwynbHjKth82a25SMovm9Dh5C7PylRAkjuiXdTGTla51RGLFFAMuA59HlRuTd1FDcZUT+9idynw==",
             "dev": true,
             "requires": {
-                "@ngtools/json-schema": "1.1.0",
-                "autoprefixer": "7.2.6",
-                "browserslist": "2.11.3",
-                "commander": "2.14.1",
-                "cpx": "1.5.0",
-                "fs-extra": "5.0.0",
-                "glob": "7.1.2",
-                "injection-js": "2.2.1",
-                "less": "2.7.3",
-                "node-sass": "4.7.2",
-                "node-sass-tilde-importer": "1.0.1",
-                "postcss": "6.0.19",
-                "postcss-discard-comments": "2.0.4",
-                "postcss-url": "7.3.1",
-                "rimraf": "2.6.2",
-                "rollup": "0.55.5",
-                "rollup-plugin-cleanup": "2.0.0",
-                "rollup-plugin-commonjs": "8.4.1",
-                "rollup-plugin-license": "0.5.0",
-                "rollup-plugin-node-resolve": "3.0.3",
-                "rxjs": "5.5.6",
-                "sorcery": "0.10.0",
-                "strip-bom": "3.0.0",
-                "stylus": "0.54.5",
-                "uglify-js": "3.3.13"
+                "@ngtools/json-schema": "^1.1.0",
+                "autoprefixer": "^7.1.1",
+                "browserslist": "^2.1.5",
+                "commander": "^2.12.0",
+                "cpx": "^1.5.0",
+                "fs-extra": "^5.0.0",
+                "glob": "^7.1.2",
+                "injection-js": "^2.2.1",
+                "less": "^2.7.2",
+                "node-sass": "^4.5.3",
+                "node-sass-tilde-importer": "^1.0.0",
+                "postcss": "^6.0.2",
+                "postcss-discard-comments": "^2.0.4",
+                "postcss-url": "^7.3.0",
+                "rimraf": "^2.6.1",
+                "rollup": "^0.55.0",
+                "rollup-plugin-cleanup": "^2.0.0",
+                "rollup-plugin-commonjs": "^8.2.1",
+                "rollup-plugin-license": "^0.5.0",
+                "rollup-plugin-node-resolve": "^3.0.0",
+                "rxjs": "^5.5.0",
+                "sorcery": "^0.10.0",
+                "strip-bom": "^3.0.0",
+                "stylus": "^0.54.5",
+                "uglify-js": "^3.0.7"
             },
             "dependencies": {
                 "autoprefixer": {
@@ -9266,9 +9266,9 @@
                     "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "fs-extra": {
@@ -9277,9 +9277,9 @@
                     "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.1"
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
                     }
                 },
                 "has-flag": {
@@ -9294,9 +9294,9 @@
                     "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.2.0"
                     }
                 },
                 "postcss-url": {
@@ -9305,11 +9305,11 @@
                     "integrity": "sha512-Ya5KIjGptgz0OtrVYfi2UbLxVAZ6Emc4Of+Grx4Sf1deWlRpFwLr8FrtkUxfqh+XiZIVkXbjQrddE10ESpNmdA==",
                     "dev": true,
                     "requires": {
-                        "mime": "1.6.0",
-                        "minimatch": "3.0.4",
-                        "mkdirp": "0.5.1",
-                        "postcss": "6.0.19",
-                        "xxhashjs": "0.2.2"
+                        "mime": "^1.4.1",
+                        "minimatch": "^3.0.4",
+                        "mkdirp": "^0.5.0",
+                        "postcss": "^6.0.1",
+                        "xxhashjs": "^0.2.1"
                     }
                 },
                 "strip-bom": {
@@ -9324,7 +9324,7 @@
                     "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -9335,7 +9335,7 @@
             "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
             "dev": true,
             "requires": {
-                "lower-case": "1.1.4"
+                "lower-case": "^1.1.1"
             }
         },
         "node-forge": {
@@ -9350,19 +9350,19 @@
             "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
             "dev": true,
             "requires": {
-                "fstream": "1.0.11",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "npmlog": "4.1.2",
-                "osenv": "0.1.5",
-                "request": "2.81.0",
-                "rimraf": "2.6.2",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "which": "1.3.0"
+                "fstream": "^1.0.0",
+                "glob": "^7.0.3",
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2 || 3 || 4",
+                "osenv": "0",
+                "request": "2",
+                "rimraf": "2",
+                "semver": "~5.3.0",
+                "tar": "^2.0.0",
+                "which": "1"
             },
             "dependencies": {
                 "nopt": {
@@ -9371,7 +9371,7 @@
                     "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                     "dev": true,
                     "requires": {
-                        "abbrev": "1.1.1"
+                        "abbrev": "1"
                     }
                 },
                 "semver": {
@@ -9388,28 +9388,28 @@
             "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "dev": true,
             "requires": {
-                "assert": "1.4.1",
-                "browserify-zlib": "0.2.0",
-                "buffer": "4.9.1",
-                "console-browserify": "1.1.0",
-                "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.12.0",
-                "domain-browser": "1.2.0",
-                "events": "1.1.1",
-                "https-browserify": "1.0.0",
-                "os-browserify": "0.3.0",
+                "assert": "^1.1.1",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^4.3.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^1.1.1",
+                "events": "^1.0.0",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
                 "path-browserify": "0.0.0",
-                "process": "0.11.10",
-                "punycode": "1.4.1",
-                "querystring-es3": "0.2.1",
-                "readable-stream": "2.3.5",
-                "stream-browserify": "2.0.1",
-                "stream-http": "2.8.0",
-                "string_decoder": "1.0.3",
-                "timers-browserify": "2.0.6",
+                "process": "^0.11.10",
+                "punycode": "^1.2.4",
+                "querystring-es3": "^0.2.0",
+                "readable-stream": "^2.3.3",
+                "stream-browserify": "^2.0.1",
+                "stream-http": "^2.7.2",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
                 "tty-browserify": "0.0.0",
-                "url": "0.11.0",
-                "util": "0.10.3",
+                "url": "^0.11.0",
+                "util": "^0.10.3",
                 "vm-browserify": "0.0.4"
             }
         },
@@ -9425,25 +9425,25 @@
             "integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
             "dev": true,
             "requires": {
-                "async-foreach": "0.1.3",
-                "chalk": "1.1.3",
-                "cross-spawn": "3.0.1",
-                "gaze": "1.1.2",
-                "get-stdin": "4.0.1",
-                "glob": "7.1.2",
-                "in-publish": "2.0.0",
-                "lodash.assign": "4.2.0",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.mergewith": "4.6.1",
-                "meow": "3.7.0",
-                "mkdirp": "0.5.1",
-                "nan": "2.9.2",
-                "node-gyp": "3.6.2",
-                "npmlog": "4.1.2",
-                "request": "2.79.0",
-                "sass-graph": "2.2.4",
-                "stdout-stream": "1.4.0",
-                "true-case-path": "1.0.2"
+                "async-foreach": "^0.1.3",
+                "chalk": "^1.1.1",
+                "cross-spawn": "^3.0.0",
+                "gaze": "^1.0.0",
+                "get-stdin": "^4.0.1",
+                "glob": "^7.0.3",
+                "in-publish": "^2.0.0",
+                "lodash.assign": "^4.2.0",
+                "lodash.clonedeep": "^4.3.2",
+                "lodash.mergewith": "^4.6.0",
+                "meow": "^3.7.0",
+                "mkdirp": "^0.5.1",
+                "nan": "^2.3.2",
+                "node-gyp": "^3.3.1",
+                "npmlog": "^4.0.0",
+                "request": "~2.79.0",
+                "sass-graph": "^2.2.4",
+                "stdout-stream": "^1.4.0",
+                "true-case-path": "^1.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9537,7 +9537,7 @@
             "integrity": "sha512-Fh9+WztCbell05Xy2KpU96Fkj5JWrs5RX/nP4ko2n6zi1/SJnw1tMXDzS1wD9ttFNy3A0jsmTFqObdPIjx35Wg==",
             "dev": true,
             "requires": {
-                "find-parent-dir": "0.3.0"
+                "find-parent-dir": "^0.3.0"
             }
         },
         "nomnom": {
@@ -9546,8 +9546,8 @@
             "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
             "dev": true,
             "requires": {
-                "colors": "0.5.1",
-                "underscore": "1.4.4"
+                "colors": "0.5.x",
+                "underscore": "~1.4.4"
             },
             "dependencies": {
                 "colors": {
@@ -9564,8 +9564,8 @@
             "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
             "dev": true,
             "requires": {
-                "abbrev": "1.1.1",
-                "osenv": "0.1.5"
+                "abbrev": "1",
+                "osenv": "^0.1.4"
             }
         },
         "normalize-git-url": {
@@ -9580,10 +9580,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.5.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -9591,7 +9591,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "normalize-range": {
@@ -9606,10 +9606,10 @@
             "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "prepend-http": "1.0.4",
-                "query-string": "4.3.4",
-                "sort-keys": "1.1.2"
+                "object-assign": "^4.0.1",
+                "prepend-http": "^1.0.0",
+                "query-string": "^4.1.0",
+                "sort-keys": "^1.0.0"
             }
         },
         "npm": {
@@ -9618,97 +9618,97 @@
             "integrity": "sha1-+Osa0A3FilUUNjtBylNCgX8L1kY=",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.1",
-                "abbrev": "1.1.0",
-                "ansi-regex": "2.1.1",
-                "ansicolors": "0.3.2",
-                "ansistyles": "0.1.3",
-                "aproba": "1.1.1",
-                "archy": "1.0.0",
-                "asap": "2.0.5",
-                "bluebird": "3.5.0",
-                "call-limit": "1.1.0",
-                "chownr": "1.0.1",
-                "cmd-shim": "2.0.2",
-                "columnify": "1.5.4",
-                "config-chain": "1.1.11",
-                "debuglog": "1.0.1",
-                "dezalgo": "1.0.3",
-                "editor": "1.0.0",
-                "fs-vacuum": "1.2.10",
-                "fs-write-stream-atomic": "1.0.10",
-                "fstream": "1.0.11",
-                "fstream-npm": "1.2.0",
-                "glob": "7.1.1",
-                "graceful-fs": "4.1.11",
-                "has-unicode": "2.0.1",
-                "hosted-git-info": "2.4.2",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "ini": "1.3.4",
-                "init-package-json": "1.10.1",
-                "lazy-property": "1.0.0",
-                "lockfile": "1.0.3",
-                "lodash._baseindexof": "3.1.0",
-                "lodash._baseuniq": "4.6.0",
-                "lodash._bindcallback": "3.0.1",
-                "lodash._cacheindexof": "3.0.2",
-                "lodash._createcache": "3.1.2",
-                "lodash._getnative": "3.9.1",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.restparam": "3.6.1",
-                "lodash.union": "4.6.0",
-                "lodash.uniq": "4.5.0",
-                "lodash.without": "4.4.0",
-                "mississippi": "1.3.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "node-gyp": "3.6.0",
-                "nopt": "4.0.1",
-                "normalize-git-url": "3.0.2",
-                "normalize-package-data": "2.3.8",
-                "npm-cache-filename": "1.0.2",
-                "npm-install-checks": "3.0.0",
-                "npm-package-arg": "4.2.1",
-                "npm-registry-client": "8.1.1",
-                "npm-user-validate": "0.1.5",
-                "npmlog": "4.0.2",
-                "once": "1.4.0",
-                "opener": "1.4.3",
-                "osenv": "0.1.4",
-                "path-is-inside": "1.0.2",
-                "read": "1.0.7",
-                "read-cmd-shim": "1.0.1",
-                "read-installed": "4.0.3",
-                "read-package-json": "2.0.5",
-                "read-package-tree": "5.1.5",
-                "readable-stream": "2.2.9",
-                "readdir-scoped-modules": "1.0.2",
-                "realize-package-specifier": "3.0.3",
-                "request": "2.81.0",
-                "retry": "0.10.1",
-                "rimraf": "2.6.1",
-                "semver": "5.3.0",
-                "sha": "2.0.1",
-                "slide": "1.1.6",
-                "sorted-object": "2.0.1",
-                "sorted-union-stream": "2.1.3",
-                "strip-ansi": "3.0.1",
-                "tar": "2.2.1",
-                "text-table": "0.2.0",
+                "JSONStream": "~1.3.1",
+                "abbrev": "~1.1.0",
+                "ansi-regex": "~2.1.1",
+                "ansicolors": "~0.3.2",
+                "ansistyles": "~0.1.3",
+                "aproba": "~1.1.1",
+                "archy": "~1.0.0",
+                "asap": "~2.0.5",
+                "bluebird": "~3.5.0",
+                "call-limit": "~1.1.0",
+                "chownr": "~1.0.1",
+                "cmd-shim": "~2.0.2",
+                "columnify": "~1.5.4",
+                "config-chain": "~1.1.11",
+                "debuglog": "*",
+                "dezalgo": "~1.0.3",
+                "editor": "~1.0.0",
+                "fs-vacuum": "~1.2.10",
+                "fs-write-stream-atomic": "~1.0.10",
+                "fstream": "~1.0.11",
+                "fstream-npm": "~1.2.0",
+                "glob": "~7.1.1",
+                "graceful-fs": "~4.1.11",
+                "has-unicode": "~2.0.1",
+                "hosted-git-info": "~2.4.2",
+                "iferr": "~0.1.5",
+                "imurmurhash": "*",
+                "inflight": "~1.0.6",
+                "inherits": "~2.0.3",
+                "ini": "~1.3.4",
+                "init-package-json": "~1.10.1",
+                "lazy-property": "~1.0.0",
+                "lockfile": "~1.0.3",
+                "lodash._baseindexof": "*",
+                "lodash._baseuniq": "~4.6.0",
+                "lodash._bindcallback": "*",
+                "lodash._cacheindexof": "*",
+                "lodash._createcache": "*",
+                "lodash._getnative": "*",
+                "lodash.clonedeep": "~4.5.0",
+                "lodash.restparam": "*",
+                "lodash.union": "~4.6.0",
+                "lodash.uniq": "~4.5.0",
+                "lodash.without": "~4.4.0",
+                "mississippi": "~1.3.0",
+                "mkdirp": "~0.5.1",
+                "move-concurrently": "~1.0.1",
+                "node-gyp": "~3.6.0",
+                "nopt": "~4.0.1",
+                "normalize-git-url": "~3.0.2",
+                "normalize-package-data": "~2.3.8",
+                "npm-cache-filename": "~1.0.2",
+                "npm-install-checks": "~3.0.0",
+                "npm-package-arg": "~4.2.1",
+                "npm-registry-client": "~8.1.1",
+                "npm-user-validate": "~0.1.5",
+                "npmlog": "~4.0.2",
+                "once": "~1.4.0",
+                "opener": "~1.4.3",
+                "osenv": "~0.1.4",
+                "path-is-inside": "~1.0.2",
+                "read": "~1.0.7",
+                "read-cmd-shim": "~1.0.1",
+                "read-installed": "~4.0.3",
+                "read-package-json": "~2.0.5",
+                "read-package-tree": "~5.1.5",
+                "readable-stream": "~2.2.9",
+                "readdir-scoped-modules": "*",
+                "realize-package-specifier": "~3.0.3",
+                "request": "~2.81.0",
+                "retry": "~0.10.1",
+                "rimraf": "~2.6.1",
+                "semver": "~5.3.0",
+                "sha": "~2.0.1",
+                "slide": "~1.1.6",
+                "sorted-object": "~2.0.1",
+                "sorted-union-stream": "~2.1.3",
+                "strip-ansi": "~3.0.1",
+                "tar": "~2.2.1",
+                "text-table": "~0.2.0",
                 "uid-number": "0.0.6",
-                "umask": "1.1.0",
-                "unique-filename": "1.1.0",
-                "unpipe": "1.0.0",
-                "update-notifier": "2.1.0",
-                "uuid": "3.0.1",
-                "validate-npm-package-license": "3.0.1",
-                "validate-npm-package-name": "3.0.0",
-                "which": "1.2.14",
-                "wrappy": "1.0.2",
-                "write-file-atomic": "1.3.3"
+                "umask": "~1.1.0",
+                "unique-filename": "~1.1.0",
+                "unpipe": "~1.0.0",
+                "update-notifier": "~2.1.0",
+                "uuid": "~3.0.1",
+                "validate-npm-package-license": "*",
+                "validate-npm-package-name": "~3.0.0",
+                "which": "~1.2.14",
+                "wrappy": "~1.0.2",
+                "write-file-atomic": "~1.3.3"
             },
             "dependencies": {
                 "JSONStream": {
@@ -9716,8 +9716,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "jsonparse": "1.3.0",
-                        "through": "2.3.8"
+                        "jsonparse": "^1.2.0",
+                        "through": ">=2.2.7 <3"
                     },
                     "dependencies": {
                         "jsonparse": {
@@ -9787,8 +9787,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "mkdirp": "0.5.1"
+                        "graceful-fs": "^4.1.2",
+                        "mkdirp": "~0.5.0"
                     }
                 },
                 "columnify": {
@@ -9796,8 +9796,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "strip-ansi": "3.0.1",
-                        "wcwidth": "1.0.0"
+                        "strip-ansi": "^3.0.0",
+                        "wcwidth": "^1.0.0"
                     },
                     "dependencies": {
                         "wcwidth": {
@@ -9805,7 +9805,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "defaults": "1.0.3"
+                                "defaults": "^1.0.0"
                             },
                             "dependencies": {
                                 "defaults": {
@@ -9813,7 +9813,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "clone": "1.0.2"
+                                        "clone": "^1.0.2"
                                     },
                                     "dependencies": {
                                         "clone": {
@@ -9832,8 +9832,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ini": "1.3.4",
-                        "proto-list": "1.2.4"
+                        "ini": "^1.3.4",
+                        "proto-list": "~1.2.1"
                     },
                     "dependencies": {
                         "proto-list": {
@@ -9864,9 +9864,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "path-is-inside": "1.0.2",
-                        "rimraf": "2.6.1"
+                        "graceful-fs": "^4.1.2",
+                        "path-is-inside": "^1.0.1",
+                        "rimraf": "^2.5.2"
                     }
                 },
                 "fs-write-stream-atomic": {
@@ -9874,10 +9874,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "iferr": "0.1.5",
-                        "imurmurhash": "0.1.4",
-                        "readable-stream": "2.2.9"
+                        "graceful-fs": "^4.1.2",
+                        "iferr": "^0.1.5",
+                        "imurmurhash": "^0.1.4",
+                        "readable-stream": "1 || 2"
                     }
                 },
                 "fstream": {
@@ -9885,10 +9885,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
+                        "graceful-fs": "^4.1.2",
+                        "inherits": "~2.0.0",
+                        "mkdirp": ">=0.5 0",
+                        "rimraf": "2"
                     }
                 },
                 "fstream-npm": {
@@ -9896,8 +9896,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fstream-ignore": "1.0.5",
-                        "inherits": "2.0.3"
+                        "fstream-ignore": "^1.0.0",
+                        "inherits": "2"
                     },
                     "dependencies": {
                         "fstream-ignore": {
@@ -9905,9 +9905,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "fstream": "1.0.11",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.3"
+                                "fstream": "^1.0.0",
+                                "inherits": "2",
+                                "minimatch": "^3.0.0"
                             },
                             "dependencies": {
                                 "minimatch": {
@@ -9915,7 +9915,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "brace-expansion": "1.1.6"
+                                        "brace-expansion": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "brace-expansion": {
@@ -9923,7 +9923,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "balanced-match": "0.4.2",
+                                                "balanced-match": "^0.4.1",
                                                 "concat-map": "0.0.1"
                                             },
                                             "dependencies": {
@@ -9950,12 +9950,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.3",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     },
                     "dependencies": {
                         "fs.realpath": {
@@ -9968,7 +9968,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "brace-expansion": "1.1.6"
+                                "brace-expansion": "^1.0.0"
                             },
                             "dependencies": {
                                 "brace-expansion": {
@@ -9976,7 +9976,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "balanced-match": "0.4.2",
+                                        "balanced-match": "^0.4.1",
                                         "concat-map": "0.0.1"
                                     },
                                     "dependencies": {
@@ -10031,8 +10031,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -10050,14 +10050,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.1",
-                        "npm-package-arg": "4.2.1",
-                        "promzard": "0.3.0",
-                        "read": "1.0.7",
-                        "read-package-json": "2.0.5",
-                        "semver": "5.3.0",
-                        "validate-npm-package-license": "3.0.1",
-                        "validate-npm-package-name": "3.0.0"
+                        "glob": "^7.1.1",
+                        "npm-package-arg": "^4.0.0 || ^5.0.0",
+                        "promzard": "^0.3.0",
+                        "read": "~1.0.1",
+                        "read-package-json": "1 || 2",
+                        "semver": "2.x || 3.x || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1",
+                        "validate-npm-package-name": "^3.0.0"
                     },
                     "dependencies": {
                         "promzard": {
@@ -10065,7 +10065,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "read": "1.0.7"
+                                "read": "1"
                             }
                         }
                     }
@@ -10090,8 +10090,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "lodash._createset": "4.0.3",
-                        "lodash._root": "3.0.1"
+                        "lodash._createset": "~4.0.0",
+                        "lodash._root": "~3.0.0"
                     },
                     "dependencies": {
                         "lodash._createset": {
@@ -10121,7 +10121,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "lodash._getnative": "3.9.1"
+                        "lodash._getnative": "^3.0.0"
                     }
                 },
                 "lodash._getnative": {
@@ -10159,16 +10159,16 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "concat-stream": "1.6.0",
-                        "duplexify": "3.5.0",
-                        "end-of-stream": "1.1.0",
-                        "flush-write-stream": "1.0.2",
-                        "from2": "2.3.0",
-                        "parallel-transform": "1.1.0",
-                        "pump": "1.0.2",
-                        "pumpify": "1.3.5",
-                        "stream-each": "1.2.0",
-                        "through2": "2.0.3"
+                        "concat-stream": "^1.5.0",
+                        "duplexify": "^3.4.2",
+                        "end-of-stream": "^1.1.0",
+                        "flush-write-stream": "^1.0.0",
+                        "from2": "^2.1.0",
+                        "parallel-transform": "^1.1.0",
+                        "pump": "^1.0.0",
+                        "pumpify": "^1.3.3",
+                        "stream-each": "^1.1.0",
+                        "through2": "^2.0.0"
                     },
                     "dependencies": {
                         "concat-stream": {
@@ -10176,9 +10176,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.2.9",
-                                "typedarray": "0.0.6"
+                                "inherits": "^2.0.3",
+                                "readable-stream": "^2.2.2",
+                                "typedarray": "^0.0.6"
                             },
                             "dependencies": {
                                 "typedarray": {
@@ -10194,9 +10194,9 @@
                             "dev": true,
                             "requires": {
                                 "end-of-stream": "1.0.0",
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.2.9",
-                                "stream-shift": "1.0.0"
+                                "inherits": "^2.0.1",
+                                "readable-stream": "^2.0.0",
+                                "stream-shift": "^1.0.0"
                             },
                             "dependencies": {
                                 "end-of-stream": {
@@ -10204,7 +10204,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "once": "1.3.3"
+                                        "once": "~1.3.0"
                                     },
                                     "dependencies": {
                                         "once": {
@@ -10212,7 +10212,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "wrappy": "1.0.2"
+                                                "wrappy": "1"
                                             }
                                         }
                                     }
@@ -10229,7 +10229,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "once": "1.3.3"
+                                "once": "~1.3.0"
                             },
                             "dependencies": {
                                 "once": {
@@ -10237,7 +10237,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "wrappy": "1.0.2"
+                                        "wrappy": "1"
                                     }
                                 }
                             }
@@ -10247,8 +10247,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.2.9"
+                                "inherits": "^2.0.1",
+                                "readable-stream": "^2.0.4"
                             }
                         },
                         "from2": {
@@ -10256,8 +10256,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.2.9"
+                                "inherits": "^2.0.1",
+                                "readable-stream": "^2.0.0"
                             }
                         },
                         "parallel-transform": {
@@ -10265,9 +10265,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "cyclist": "0.2.2",
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.2.9"
+                                "cyclist": "~0.2.2",
+                                "inherits": "^2.0.3",
+                                "readable-stream": "^2.1.5"
                             },
                             "dependencies": {
                                 "cyclist": {
@@ -10282,8 +10282,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "end-of-stream": "1.1.0",
-                                "once": "1.4.0"
+                                "end-of-stream": "^1.1.0",
+                                "once": "^1.3.1"
                             }
                         },
                         "pumpify": {
@@ -10291,9 +10291,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "duplexify": "3.5.0",
-                                "inherits": "2.0.3",
-                                "pump": "1.0.2"
+                                "duplexify": "^3.1.2",
+                                "inherits": "^2.0.1",
+                                "pump": "^1.0.0"
                             }
                         },
                         "stream-each": {
@@ -10301,8 +10301,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "end-of-stream": "1.1.0",
-                                "stream-shift": "1.0.0"
+                                "end-of-stream": "^1.1.0",
+                                "stream-shift": "^1.0.0"
                             },
                             "dependencies": {
                                 "stream-shift": {
@@ -10317,8 +10317,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "readable-stream": "2.2.9",
-                                "xtend": "4.0.1"
+                                "readable-stream": "^2.1.5",
+                                "xtend": "~4.0.1"
                             },
                             "dependencies": {
                                 "xtend": {
@@ -10350,12 +10350,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aproba": "1.1.1",
-                        "copy-concurrently": "1.0.3",
-                        "fs-write-stream-atomic": "1.0.10",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1",
-                        "run-queue": "1.0.3"
+                        "aproba": "^1.1.1",
+                        "copy-concurrently": "^1.0.0",
+                        "fs-write-stream-atomic": "^1.0.8",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.5.4",
+                        "run-queue": "^1.0.3"
                     },
                     "dependencies": {
                         "copy-concurrently": {
@@ -10363,12 +10363,12 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "aproba": "1.1.1",
-                                "fs-write-stream-atomic": "1.0.10",
-                                "iferr": "0.1.5",
-                                "mkdirp": "0.5.1",
-                                "rimraf": "2.6.1",
-                                "run-queue": "1.0.3"
+                                "aproba": "^1.1.1",
+                                "fs-write-stream-atomic": "^1.0.8",
+                                "iferr": "^0.1.5",
+                                "mkdirp": "^0.5.1",
+                                "rimraf": "^2.5.4",
+                                "run-queue": "^1.0.0"
                             }
                         },
                         "run-queue": {
@@ -10376,7 +10376,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "aproba": "1.1.1"
+                                "aproba": "^1.1.1"
                             }
                         }
                     }
@@ -10386,19 +10386,19 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "glob": "7.1.1",
-                        "graceful-fs": "4.1.11",
-                        "minimatch": "3.0.3",
-                        "mkdirp": "0.5.1",
-                        "nopt": "3.0.6",
-                        "npmlog": "4.0.2",
-                        "osenv": "0.1.4",
-                        "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "which": "1.2.14"
+                        "fstream": "^1.0.0",
+                        "glob": "^7.0.3",
+                        "graceful-fs": "^4.1.2",
+                        "minimatch": "^3.0.2",
+                        "mkdirp": "^0.5.0",
+                        "nopt": "2 || 3",
+                        "npmlog": "0 || 1 || 2 || 3 || 4",
+                        "osenv": "0",
+                        "request": "2",
+                        "rimraf": "2",
+                        "semver": "~5.3.0",
+                        "tar": "^2.0.0",
+                        "which": "1"
                     },
                     "dependencies": {
                         "minimatch": {
@@ -10406,7 +10406,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "brace-expansion": "1.1.6"
+                                "brace-expansion": "^1.0.0"
                             },
                             "dependencies": {
                                 "brace-expansion": {
@@ -10414,7 +10414,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "balanced-match": "0.4.2",
+                                        "balanced-match": "^0.4.1",
                                         "concat-map": "0.0.1"
                                     },
                                     "dependencies": {
@@ -10437,7 +10437,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "abbrev": "1.1.0"
+                                "abbrev": "1"
                             }
                         }
                     }
@@ -10447,8 +10447,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     },
                     "dependencies": {
                         "osenv": {
@@ -10456,8 +10456,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "os-homedir": "1.0.2",
-                                "os-tmpdir": "1.0.2"
+                                "os-homedir": "^1.0.0",
+                                "os-tmpdir": "^1.0.0"
                             },
                             "dependencies": {
                                 "os-homedir": {
@@ -10479,10 +10479,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hosted-git-info": "2.4.2",
-                        "is-builtin-module": "1.0.0",
-                        "semver": "5.3.0",
-                        "validate-npm-package-license": "3.0.1"
+                        "hosted-git-info": "^2.1.4",
+                        "is-builtin-module": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
                     },
                     "dependencies": {
                         "is-builtin-module": {
@@ -10490,7 +10490,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "builtin-modules": "1.1.1"
+                                "builtin-modules": "^1.0.0"
                             },
                             "dependencies": {
                                 "builtin-modules": {
@@ -10512,8 +10512,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hosted-git-info": "2.4.2",
-                        "semver": "5.3.0"
+                        "hosted-git-info": "^2.1.5",
+                        "semver": "^5.1.0"
                     }
                 },
                 "npm-registry-client": {
@@ -10521,16 +10521,16 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "concat-stream": "1.6.0",
-                        "graceful-fs": "4.1.11",
-                        "normalize-package-data": "2.3.8",
-                        "npm-package-arg": "4.2.1",
-                        "npmlog": "4.0.2",
-                        "once": "1.4.0",
-                        "request": "2.81.0",
-                        "retry": "0.10.1",
-                        "semver": "5.3.0",
-                        "slide": "1.1.6"
+                        "concat-stream": "^1.5.2",
+                        "graceful-fs": "^4.1.6",
+                        "normalize-package-data": "~1.0.1 || ^2.0.0",
+                        "npm-package-arg": "^3.0.0 || ^4.0.0 || ^5.0.0",
+                        "npmlog": "2 || ^3.1.0 || ^4.0.0",
+                        "once": "^1.3.3",
+                        "request": "^2.74.0",
+                        "retry": "^0.10.0",
+                        "semver": "2 >=2.2.1 || 3.x || 4 || 5",
+                        "slide": "^1.1.3"
                     },
                     "dependencies": {
                         "concat-stream": {
@@ -10538,9 +10538,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "2.2.9",
-                                "typedarray": "0.0.6"
+                                "inherits": "^2.0.3",
+                                "readable-stream": "^2.2.2",
+                                "typedarray": "^0.0.6"
                             },
                             "dependencies": {
                                 "typedarray": {
@@ -10562,10 +10562,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.1",
+                        "set-blocking": "~2.0.0"
                     },
                     "dependencies": {
                         "are-we-there-yet": {
@@ -10573,8 +10573,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "delegates": "1.0.0",
-                                "readable-stream": "2.2.9"
+                                "delegates": "^1.0.0",
+                                "readable-stream": "^2.0.6"
                             },
                             "dependencies": {
                                 "delegates": {
@@ -10594,14 +10594,14 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "aproba": "1.1.1",
-                                "console-control-strings": "1.1.0",
-                                "has-unicode": "2.0.1",
-                                "object-assign": "4.1.1",
-                                "signal-exit": "3.0.2",
-                                "string-width": "1.0.2",
-                                "strip-ansi": "3.0.1",
-                                "wide-align": "1.1.0"
+                                "aproba": "^1.0.3",
+                                "console-control-strings": "^1.0.0",
+                                "has-unicode": "^2.0.0",
+                                "object-assign": "^4.1.0",
+                                "signal-exit": "^3.0.0",
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wide-align": "^1.1.0"
                             },
                             "dependencies": {
                                 "object-assign": {
@@ -10619,9 +10619,9 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "code-point-at": "1.1.0",
-                                        "is-fullwidth-code-point": "1.0.0",
-                                        "strip-ansi": "3.0.1"
+                                        "code-point-at": "^1.0.0",
+                                        "is-fullwidth-code-point": "^1.0.0",
+                                        "strip-ansi": "^3.0.0"
                                     },
                                     "dependencies": {
                                         "code-point-at": {
@@ -10634,7 +10634,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "number-is-nan": "1.0.1"
+                                                "number-is-nan": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "number-is-nan": {
@@ -10651,7 +10651,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "string-width": "1.0.2"
+                                        "string-width": "^1.0.1"
                                     }
                                 }
                             }
@@ -10668,7 +10668,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "opener": {
@@ -10681,8 +10681,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     },
                     "dependencies": {
                         "os-homedir": {
@@ -10707,7 +10707,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mute-stream": "0.0.5"
+                        "mute-stream": "~0.0.4"
                     },
                     "dependencies": {
                         "mute-stream": {
@@ -10722,7 +10722,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11"
+                        "graceful-fs": "^4.1.2"
                     }
                 },
                 "read-installed": {
@@ -10730,13 +10730,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "graceful-fs": "4.1.11",
-                        "read-package-json": "2.0.5",
-                        "readdir-scoped-modules": "1.0.2",
-                        "semver": "5.3.0",
-                        "slide": "1.1.6",
-                        "util-extend": "1.0.3"
+                        "debuglog": "^1.0.1",
+                        "graceful-fs": "^4.1.2",
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "slide": "~1.1.3",
+                        "util-extend": "^1.0.1"
                     },
                     "dependencies": {
                         "util-extend": {
@@ -10751,10 +10751,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.1",
-                        "graceful-fs": "4.1.11",
-                        "json-parse-helpfulerror": "1.0.3",
-                        "normalize-package-data": "2.3.8"
+                        "glob": "^7.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "json-parse-helpfulerror": "^1.0.2",
+                        "normalize-package-data": "^2.0.0"
                     },
                     "dependencies": {
                         "json-parse-helpfulerror": {
@@ -10762,7 +10762,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "jju": "1.3.0"
+                                "jju": "^1.1.0"
                             },
                             "dependencies": {
                                 "jju": {
@@ -10779,11 +10779,11 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "dezalgo": "1.0.3",
-                        "once": "1.4.0",
-                        "read-package-json": "2.0.5",
-                        "readdir-scoped-modules": "1.0.2"
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "once": "^1.3.0",
+                        "read-package-json": "^2.0.0",
+                        "readdir-scoped-modules": "^1.0.0"
                     }
                 },
                 "readable-stream": {
@@ -10791,13 +10791,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.0",
-                        "util-deprecate": "1.0.2"
+                        "buffer-shims": "~1.0.0",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~1.0.0",
+                        "util-deprecate": "~1.0.1"
                     },
                     "dependencies": {
                         "buffer-shims": {
@@ -10820,7 +10820,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "buffer-shims": "1.0.0"
+                                "buffer-shims": "~1.0.0"
                             }
                         },
                         "util-deprecate": {
@@ -10835,10 +10835,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debuglog": "1.0.1",
-                        "dezalgo": "1.0.3",
-                        "graceful-fs": "4.1.11",
-                        "once": "1.4.0"
+                        "debuglog": "^1.0.1",
+                        "dezalgo": "^1.0.0",
+                        "graceful-fs": "^4.1.2",
+                        "once": "^1.3.0"
                     }
                 },
                 "request": {
@@ -10846,28 +10846,28 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.0",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.2",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.14",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~4.2.1",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "performance-now": "^0.2.0",
+                        "qs": "~6.4.0",
+                        "safe-buffer": "^5.0.1",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.0.0"
                     },
                     "dependencies": {
                         "aws-sign2": {
@@ -10890,7 +10890,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "delayed-stream": "1.0.0"
+                                "delayed-stream": "~1.0.0"
                             },
                             "dependencies": {
                                 "delayed-stream": {
@@ -10915,9 +10915,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "asynckit": "0.4.0",
-                                "combined-stream": "1.0.5",
-                                "mime-types": "2.1.14"
+                                "asynckit": "^0.4.0",
+                                "combined-stream": "^1.0.5",
+                                "mime-types": "^2.1.12"
                             },
                             "dependencies": {
                                 "asynckit": {
@@ -10932,8 +10932,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ajv": "4.11.4",
-                                "har-schema": "1.0.5"
+                                "ajv": "^4.9.1",
+                                "har-schema": "^1.0.5"
                             },
                             "dependencies": {
                                 "ajv": {
@@ -10941,8 +10941,8 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "co": "4.6.0",
-                                        "json-stable-stringify": "1.0.1"
+                                        "co": "^4.6.0",
+                                        "json-stable-stringify": "^1.0.1"
                                     },
                                     "dependencies": {
                                         "co": {
@@ -10955,7 +10955,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "jsonify": "0.0.0"
+                                                "jsonify": "~0.0.0"
                                             },
                                             "dependencies": {
                                                 "jsonify": {
@@ -10979,10 +10979,10 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "boom": "2.10.1",
-                                "cryptiles": "2.0.5",
-                                "hoek": "2.16.3",
-                                "sntp": "1.0.9"
+                                "boom": "2.x.x",
+                                "cryptiles": "2.x.x",
+                                "hoek": "2.x.x",
+                                "sntp": "1.x.x"
                             },
                             "dependencies": {
                                 "boom": {
@@ -10990,7 +10990,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "hoek": "2.16.3"
+                                        "hoek": "2.x.x"
                                     }
                                 },
                                 "cryptiles": {
@@ -10998,7 +10998,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "boom": "2.10.1"
+                                        "boom": "2.x.x"
                                     }
                                 },
                                 "hoek": {
@@ -11011,7 +11011,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "hoek": "2.16.3"
+                                        "hoek": "2.x.x"
                                     }
                                 }
                             }
@@ -11021,9 +11021,9 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "assert-plus": "0.2.0",
-                                "jsprim": "1.3.1",
-                                "sshpk": "1.11.0"
+                                "assert-plus": "^0.2.0",
+                                "jsprim": "^1.2.2",
+                                "sshpk": "^1.7.0"
                             },
                             "dependencies": {
                                 "assert-plus": {
@@ -11066,15 +11066,15 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "asn1": "0.2.3",
-                                        "assert-plus": "1.0.0",
-                                        "bcrypt-pbkdf": "1.0.1",
-                                        "dashdash": "1.14.1",
-                                        "ecc-jsbn": "0.1.1",
-                                        "getpass": "0.1.6",
-                                        "jodid25519": "1.0.2",
-                                        "jsbn": "0.1.1",
-                                        "tweetnacl": "0.14.5"
+                                        "asn1": "~0.2.3",
+                                        "assert-plus": "^1.0.0",
+                                        "bcrypt-pbkdf": "^1.0.0",
+                                        "dashdash": "^1.12.0",
+                                        "ecc-jsbn": "~0.1.1",
+                                        "getpass": "^0.1.1",
+                                        "jodid25519": "^1.0.0",
+                                        "jsbn": "~0.1.0",
+                                        "tweetnacl": "~0.14.0"
                                     },
                                     "dependencies": {
                                         "asn1": {
@@ -11093,7 +11093,7 @@
                                             "dev": true,
                                             "optional": true,
                                             "requires": {
-                                                "tweetnacl": "0.14.5"
+                                                "tweetnacl": "^0.14.3"
                                             }
                                         },
                                         "dashdash": {
@@ -11101,7 +11101,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "assert-plus": "1.0.0"
+                                                "assert-plus": "^1.0.0"
                                             }
                                         },
                                         "ecc-jsbn": {
@@ -11110,7 +11110,7 @@
                                             "dev": true,
                                             "optional": true,
                                             "requires": {
-                                                "jsbn": "0.1.1"
+                                                "jsbn": "~0.1.0"
                                             }
                                         },
                                         "getpass": {
@@ -11118,7 +11118,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "assert-plus": "1.0.0"
+                                                "assert-plus": "^1.0.0"
                                             }
                                         },
                                         "jodid25519": {
@@ -11127,7 +11127,7 @@
                                             "dev": true,
                                             "optional": true,
                                             "requires": {
-                                                "jsbn": "0.1.1"
+                                                "jsbn": "~0.1.0"
                                             }
                                         },
                                         "jsbn": {
@@ -11166,7 +11166,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "mime-db": "1.26.0"
+                                "mime-db": "~1.26.0"
                             },
                             "dependencies": {
                                 "mime-db": {
@@ -11206,7 +11206,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "punycode": "1.4.1"
+                                "punycode": "^1.4.1"
                             },
                             "dependencies": {
                                 "punycode": {
@@ -11221,7 +11221,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "5.0.1"
+                                "safe-buffer": "^5.0.1"
                             }
                         }
                     }
@@ -11236,7 +11236,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.1"
+                        "glob": "^7.0.5"
                     }
                 },
                 "semver": {
@@ -11249,8 +11249,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "readable-stream": "2.2.9"
+                        "graceful-fs": "^4.1.2",
+                        "readable-stream": "^2.0.2"
                     }
                 },
                 "slide": {
@@ -11268,8 +11268,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "from2": "1.3.0",
-                        "stream-iterate": "1.1.1"
+                        "from2": "^1.3.0",
+                        "stream-iterate": "^1.1.0"
                     },
                     "dependencies": {
                         "from2": {
@@ -11277,8 +11277,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "inherits": "2.0.3",
-                                "readable-stream": "1.1.14"
+                                "inherits": "~2.0.1",
+                                "readable-stream": "~1.1.10"
                             },
                             "dependencies": {
                                 "readable-stream": {
@@ -11286,10 +11286,10 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "core-util-is": "1.0.2",
-                                        "inherits": "2.0.3",
+                                        "core-util-is": "~1.0.0",
+                                        "inherits": "~2.0.1",
                                         "isarray": "0.0.1",
-                                        "string_decoder": "0.10.31"
+                                        "string_decoder": "~0.10.x"
                                     },
                                     "dependencies": {
                                         "core-util-is": {
@@ -11329,7 +11329,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "tar": {
@@ -11337,9 +11337,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "block-stream": "0.0.8",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
+                        "block-stream": "*",
+                        "fstream": "^1.0.2",
+                        "inherits": "2"
                     },
                     "dependencies": {
                         "block-stream": {
@@ -11347,7 +11347,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "inherits": "2.0.3"
+                                "inherits": "~2.0.0"
                             }
                         }
                     }
@@ -11372,7 +11372,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "unique-slug": "2.0.0"
+                        "unique-slug": "^2.0.0"
                     }
                 },
                 "unique-slug": {
@@ -11381,7 +11381,7 @@
                     "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
                     "dev": true,
                     "requires": {
-                        "imurmurhash": "0.1.4"
+                        "imurmurhash": "^0.1.4"
                     }
                 },
                 "unpipe": {
@@ -11394,14 +11394,14 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "boxen": "1.0.0",
-                        "chalk": "1.1.3",
-                        "configstore": "3.0.0",
-                        "is-npm": "1.0.0",
-                        "latest-version": "3.0.0",
-                        "lazy-req": "2.0.0",
-                        "semver-diff": "2.1.0",
-                        "xdg-basedir": "3.0.0"
+                        "boxen": "^1.0.0",
+                        "chalk": "^1.0.0",
+                        "configstore": "^3.0.0",
+                        "is-npm": "^1.0.0",
+                        "latest-version": "^3.0.0",
+                        "lazy-req": "^2.0.0",
+                        "semver-diff": "^2.0.0",
+                        "xdg-basedir": "^3.0.0"
                     },
                     "dependencies": {
                         "boxen": {
@@ -11409,13 +11409,13 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-align": "1.1.0",
-                                "camelcase": "4.0.0",
-                                "chalk": "1.1.3",
-                                "cli-boxes": "1.0.0",
-                                "string-width": "2.0.0",
-                                "term-size": "0.1.1",
-                                "widest-line": "1.0.0"
+                                "ansi-align": "^1.1.0",
+                                "camelcase": "^4.0.0",
+                                "chalk": "^1.1.1",
+                                "cli-boxes": "^1.0.0",
+                                "string-width": "^2.0.0",
+                                "term-size": "^0.1.0",
+                                "widest-line": "^1.0.0"
                             },
                             "dependencies": {
                                 "ansi-align": {
@@ -11423,7 +11423,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "string-width": "1.0.2"
+                                        "string-width": "^1.0.1"
                                     },
                                     "dependencies": {
                                         "string-width": {
@@ -11431,9 +11431,9 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "code-point-at": "1.1.0",
-                                                "is-fullwidth-code-point": "1.0.0",
-                                                "strip-ansi": "3.0.1"
+                                                "code-point-at": "^1.0.0",
+                                                "is-fullwidth-code-point": "^1.0.0",
+                                                "strip-ansi": "^3.0.0"
                                             },
                                             "dependencies": {
                                                 "code-point-at": {
@@ -11446,7 +11446,7 @@
                                                     "bundled": true,
                                                     "dev": true,
                                                     "requires": {
-                                                        "number-is-nan": "1.0.1"
+                                                        "number-is-nan": "^1.0.0"
                                                     },
                                                     "dependencies": {
                                                         "number-is-nan": {
@@ -11475,8 +11475,8 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-fullwidth-code-point": "2.0.0",
-                                        "strip-ansi": "3.0.1"
+                                        "is-fullwidth-code-point": "^2.0.0",
+                                        "strip-ansi": "^3.0.0"
                                     },
                                     "dependencies": {
                                         "is-fullwidth-code-point": {
@@ -11491,7 +11491,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "execa": "0.4.0"
+                                        "execa": "^0.4.0"
                                     },
                                     "dependencies": {
                                         "execa": {
@@ -11499,12 +11499,12 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "cross-spawn-async": "2.2.5",
-                                                "is-stream": "1.1.0",
-                                                "npm-run-path": "1.0.0",
-                                                "object-assign": "4.1.1",
-                                                "path-key": "1.0.0",
-                                                "strip-eof": "1.0.0"
+                                                "cross-spawn-async": "^2.1.1",
+                                                "is-stream": "^1.1.0",
+                                                "npm-run-path": "^1.0.0",
+                                                "object-assign": "^4.0.1",
+                                                "path-key": "^1.0.0",
+                                                "strip-eof": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "cross-spawn-async": {
@@ -11512,8 +11512,8 @@
                                                     "bundled": true,
                                                     "dev": true,
                                                     "requires": {
-                                                        "lru-cache": "4.0.2",
-                                                        "which": "1.2.14"
+                                                        "lru-cache": "^4.0.0",
+                                                        "which": "^1.2.8"
                                                     },
                                                     "dependencies": {
                                                         "lru-cache": {
@@ -11521,8 +11521,8 @@
                                                             "bundled": true,
                                                             "dev": true,
                                                             "requires": {
-                                                                "pseudomap": "1.0.2",
-                                                                "yallist": "2.0.0"
+                                                                "pseudomap": "^1.0.1",
+                                                                "yallist": "^2.0.0"
                                                             },
                                                             "dependencies": {
                                                                 "pseudomap": {
@@ -11549,7 +11549,7 @@
                                                     "bundled": true,
                                                     "dev": true,
                                                     "requires": {
-                                                        "path-key": "1.0.0"
+                                                        "path-key": "^1.0.0"
                                                     }
                                                 },
                                                 "object-assign": {
@@ -11576,7 +11576,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "string-width": "1.0.2"
+                                        "string-width": "^1.0.1"
                                     },
                                     "dependencies": {
                                         "string-width": {
@@ -11584,9 +11584,9 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "code-point-at": "1.1.0",
-                                                "is-fullwidth-code-point": "1.0.0",
-                                                "strip-ansi": "3.0.1"
+                                                "code-point-at": "^1.0.0",
+                                                "is-fullwidth-code-point": "^1.0.0",
+                                                "strip-ansi": "^3.0.0"
                                             },
                                             "dependencies": {
                                                 "code-point-at": {
@@ -11599,7 +11599,7 @@
                                                     "bundled": true,
                                                     "dev": true,
                                                     "requires": {
-                                                        "number-is-nan": "1.0.1"
+                                                        "number-is-nan": "^1.0.0"
                                                     },
                                                     "dependencies": {
                                                         "number-is-nan": {
@@ -11620,11 +11620,11 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "ansi-styles": "2.2.1",
-                                "escape-string-regexp": "1.0.5",
-                                "has-ansi": "2.0.0",
-                                "strip-ansi": "3.0.1",
-                                "supports-color": "2.0.0"
+                                "ansi-styles": "^2.2.1",
+                                "escape-string-regexp": "^1.0.2",
+                                "has-ansi": "^2.0.0",
+                                "strip-ansi": "^3.0.0",
+                                "supports-color": "^2.0.0"
                             },
                             "dependencies": {
                                 "ansi-styles": {
@@ -11642,7 +11642,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "ansi-regex": "2.1.1"
+                                        "ansi-regex": "^2.0.0"
                                     }
                                 },
                                 "supports-color": {
@@ -11657,12 +11657,12 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "dot-prop": "4.1.1",
-                                "graceful-fs": "4.1.11",
-                                "mkdirp": "0.5.1",
-                                "unique-string": "1.0.0",
-                                "write-file-atomic": "1.3.3",
-                                "xdg-basedir": "3.0.0"
+                                "dot-prop": "^4.1.0",
+                                "graceful-fs": "^4.1.2",
+                                "mkdirp": "^0.5.0",
+                                "unique-string": "^1.0.0",
+                                "write-file-atomic": "^1.1.2",
+                                "xdg-basedir": "^3.0.0"
                             },
                             "dependencies": {
                                 "dot-prop": {
@@ -11670,7 +11670,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "is-obj": "1.0.1"
+                                        "is-obj": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "is-obj": {
@@ -11685,7 +11685,7 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "crypto-random-string": "1.0.0"
+                                        "crypto-random-string": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "crypto-random-string": {
@@ -11707,7 +11707,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "package-json": "3.1.0"
+                                "package-json": "^3.0.0"
                             },
                             "dependencies": {
                                 "package-json": {
@@ -11715,10 +11715,10 @@
                                     "bundled": true,
                                     "dev": true,
                                     "requires": {
-                                        "got": "6.7.1",
-                                        "registry-auth-token": "3.1.0",
-                                        "registry-url": "3.1.0",
-                                        "semver": "5.3.0"
+                                        "got": "^6.7.1",
+                                        "registry-auth-token": "^3.0.1",
+                                        "registry-url": "^3.0.3",
+                                        "semver": "^5.1.0"
                                     },
                                     "dependencies": {
                                         "got": {
@@ -11726,17 +11726,17 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "create-error-class": "3.0.2",
-                                                "duplexer3": "0.1.4",
-                                                "get-stream": "3.0.0",
-                                                "is-redirect": "1.0.0",
-                                                "is-retry-allowed": "1.1.0",
-                                                "is-stream": "1.1.0",
-                                                "lowercase-keys": "1.0.0",
-                                                "safe-buffer": "5.0.1",
-                                                "timed-out": "4.0.1",
-                                                "unzip-response": "2.0.1",
-                                                "url-parse-lax": "1.0.0"
+                                                "create-error-class": "^3.0.0",
+                                                "duplexer3": "^0.1.4",
+                                                "get-stream": "^3.0.0",
+                                                "is-redirect": "^1.0.0",
+                                                "is-retry-allowed": "^1.0.0",
+                                                "is-stream": "^1.0.0",
+                                                "lowercase-keys": "^1.0.0",
+                                                "safe-buffer": "^5.0.1",
+                                                "timed-out": "^4.0.0",
+                                                "unzip-response": "^2.0.1",
+                                                "url-parse-lax": "^1.0.0"
                                             },
                                             "dependencies": {
                                                 "create-error-class": {
@@ -11744,7 +11744,7 @@
                                                     "bundled": true,
                                                     "dev": true,
                                                     "requires": {
-                                                        "capture-stack-trace": "1.0.0"
+                                                        "capture-stack-trace": "^1.0.0"
                                                     },
                                                     "dependencies": {
                                                         "capture-stack-trace": {
@@ -11804,7 +11804,7 @@
                                                     "bundled": true,
                                                     "dev": true,
                                                     "requires": {
-                                                        "prepend-http": "1.0.4"
+                                                        "prepend-http": "^1.0.1"
                                                     },
                                                     "dependencies": {
                                                         "prepend-http": {
@@ -11821,7 +11821,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "rc": "1.1.7"
+                                                "rc": "^1.1.6"
                                             },
                                             "dependencies": {
                                                 "rc": {
@@ -11829,10 +11829,10 @@
                                                     "bundled": true,
                                                     "dev": true,
                                                     "requires": {
-                                                        "deep-extend": "0.4.1",
-                                                        "ini": "1.3.4",
-                                                        "minimist": "1.2.0",
-                                                        "strip-json-comments": "2.0.1"
+                                                        "deep-extend": "~0.4.0",
+                                                        "ini": "~1.3.0",
+                                                        "minimist": "^1.2.0",
+                                                        "strip-json-comments": "~2.0.1"
                                                     },
                                                     "dependencies": {
                                                         "deep-extend": {
@@ -11859,7 +11859,7 @@
                                             "bundled": true,
                                             "dev": true,
                                             "requires": {
-                                                "rc": "1.1.7"
+                                                "rc": "^1.0.1"
                                             },
                                             "dependencies": {
                                                 "rc": {
@@ -11867,10 +11867,10 @@
                                                     "bundled": true,
                                                     "dev": true,
                                                     "requires": {
-                                                        "deep-extend": "0.4.1",
-                                                        "ini": "1.3.4",
-                                                        "minimist": "1.2.0",
-                                                        "strip-json-comments": "2.0.1"
+                                                        "deep-extend": "~0.4.0",
+                                                        "ini": "~1.3.0",
+                                                        "minimist": "^1.2.0",
+                                                        "strip-json-comments": "~2.0.1"
                                                     },
                                                     "dependencies": {
                                                         "deep-extend": {
@@ -11906,7 +11906,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "semver": "5.3.0"
+                                "semver": "^5.0.3"
                             }
                         },
                         "xdg-basedir": {
@@ -11926,8 +11926,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "spdx-correct": "1.0.2",
-                        "spdx-expression-parse": "1.0.2"
+                        "spdx-correct": "~1.0.0",
+                        "spdx-expression-parse": "~1.0.0"
                     },
                     "dependencies": {
                         "spdx-correct": {
@@ -11935,7 +11935,7 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "spdx-license-ids": "1.2.0"
+                                "spdx-license-ids": "^1.0.2"
                             },
                             "dependencies": {
                                 "spdx-license-ids": {
@@ -11950,8 +11950,8 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "spdx-exceptions": "1.0.4",
-                                "spdx-license-ids": "1.2.0"
+                                "spdx-exceptions": "^1.0.4",
+                                "spdx-license-ids": "^1.0.0"
                             },
                             "dependencies": {
                                 "spdx-exceptions": {
@@ -11968,7 +11968,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "builtins": "1.0.3"
+                        "builtins": "^1.0.3"
                     },
                     "dependencies": {
                         "builtins": {
@@ -11983,7 +11983,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     },
                     "dependencies": {
                         "isexe": {
@@ -12003,9 +12003,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "imurmurhash": "0.1.4",
-                        "slide": "1.1.6"
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "slide": "^1.1.5"
                     }
                 }
             }
@@ -12016,7 +12016,7 @@
             "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
             "dev": true,
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^2.3.0 || 3.x || 4 || 5"
             }
         },
         "npm-package-arg": {
@@ -12025,8 +12025,8 @@
             "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.5.0",
-                "semver": "5.5.0"
+                "hosted-git-info": "^2.1.5",
+                "semver": "^5.1.0"
             }
         },
         "npm-run-all": {
@@ -12035,15 +12035,15 @@
             "integrity": "sha512-Z2aRlajMK4SQ8u19ZA75NZZu7wupfCNQWdYosIi8S6FgBdGf/8Y6Hgyjdc8zU2cYmIRVCx1nM80tJPkdEd+UYg==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "chalk": "2.2.2",
-                "cross-spawn": "5.1.0",
-                "memorystream": "0.3.1",
-                "minimatch": "3.0.4",
-                "ps-tree": "1.1.0",
-                "read-pkg": "3.0.0",
-                "shell-quote": "1.6.1",
-                "string.prototype.padend": "3.0.0"
+                "ansi-styles": "^3.2.0",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^5.1.0",
+                "memorystream": "^0.3.1",
+                "minimatch": "^3.0.4",
+                "ps-tree": "^1.1.0",
+                "read-pkg": "^3.0.0",
+                "shell-quote": "^1.6.1",
+                "string.prototype.padend": "^3.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -12052,9 +12052,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "4.1.1",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.0"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "load-json-file": {
@@ -12063,10 +12063,10 @@
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "4.0.0",
-                        "pify": "3.0.0",
-                        "strip-bom": "3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "parse-json": {
@@ -12075,8 +12075,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.1",
-                        "json-parse-better-errors": "1.0.1"
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
                     }
                 },
                 "read-pkg": {
@@ -12085,9 +12085,9 @@
                     "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "4.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "3.0.0"
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
                     }
                 },
                 "strip-bom": {
@@ -12104,7 +12104,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "npmlog": {
@@ -12113,10 +12113,10 @@
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
             "dev": true,
             "requires": {
-                "are-we-there-yet": "1.1.4",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
             }
         },
         "nth-check": {
@@ -12125,7 +12125,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "null-check": {
@@ -12170,9 +12170,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -12181,7 +12181,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -12190,7 +12190,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -12199,7 +12199,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -12208,9 +12208,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -12241,7 +12241,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -12257,8 +12257,8 @@
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "object.pick": {
@@ -12267,7 +12267,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -12305,7 +12305,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "openurl": {
@@ -12320,7 +12320,7 @@
             "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
             "dev": true,
             "requires": {
-                "is-wsl": "1.1.0"
+                "is-wsl": "^1.1.0"
             }
         },
         "optimist": {
@@ -12329,8 +12329,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.2"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             },
             "dependencies": {
                 "minimist": {
@@ -12347,8 +12347,8 @@
             "integrity": "sha512-Fjn7wyyadPAriuH2DHamDQw5B8GohEWbroBkKoPeP+vSF2PIAPI7WDihi8WieMRb/At4q7Ea7zTKaMDuSoIAAg==",
             "dev": true,
             "requires": {
-                "cssnano": "3.10.0",
-                "last-call-webpack-plugin": "2.1.2"
+                "cssnano": "^3.4.0",
+                "last-call-webpack-plugin": "^2.1.2"
             }
         },
         "options": {
@@ -12363,7 +12363,7 @@
             "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
             "dev": true,
             "requires": {
-                "url-parse": "1.0.5"
+                "url-parse": "1.0.x"
             },
             "dependencies": {
                 "url-parse": {
@@ -12372,8 +12372,8 @@
                     "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
                     "dev": true,
                     "requires": {
-                        "querystringify": "0.0.4",
-                        "requires-port": "1.0.0"
+                        "querystringify": "0.0.x",
+                        "requires-port": "1.0.x"
                     }
                 }
             }
@@ -12396,7 +12396,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
             }
         },
         "os-tmpdir": {
@@ -12411,8 +12411,8 @@
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
             }
         },
         "p-finally": {
@@ -12427,7 +12427,7 @@
             "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
             "dev": true,
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
@@ -12436,7 +12436,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "1.2.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-map": {
@@ -12457,10 +12457,10 @@
             "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
             "dev": true,
             "requires": {
-                "got": "6.7.1",
-                "registry-auth-token": "3.3.2",
-                "registry-url": "3.1.0",
-                "semver": "5.5.0"
+                "got": "^6.7.1",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
             }
         },
         "pako": {
@@ -12475,9 +12475,9 @@
             "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
             "dev": true,
             "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "cyclist": "~0.2.2",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
             }
         },
         "param-case": {
@@ -12486,7 +12486,7 @@
             "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2"
+                "no-case": "^2.2.0"
             }
         },
         "parse-asn1": {
@@ -12495,11 +12495,11 @@
             "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
             "dev": true,
             "requires": {
-                "asn1.js": "4.10.1",
-                "browserify-aes": "1.1.1",
-                "create-hash": "1.1.3",
-                "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.14"
+                "asn1.js": "^4.0.0",
+                "browserify-aes": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3"
             }
         },
         "parse-glob": {
@@ -12507,10 +12507,10 @@
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "parse-json": {
@@ -12519,7 +12519,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -12534,7 +12534,7 @@
             "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
             "dev": true,
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseqs": {
@@ -12543,7 +12543,7 @@
             "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
             "dev": true,
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseuri": {
@@ -12552,7 +12552,7 @@
             "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
             "dev": true,
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseurl": {
@@ -12620,7 +12620,7 @@
             "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "pause-stream": {
@@ -12629,7 +12629,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pbkdf2": {
@@ -12638,11 +12638,11 @@
             "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
             "dev": true,
             "requires": {
-                "create-hash": "1.1.3",
-                "create-hmac": "1.1.6",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
-                "sha.js": "2.4.10"
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "performance-now": {
@@ -12669,7 +12669,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkg-dir": {
@@ -12678,7 +12678,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             }
         },
         "pkginfo": {
@@ -12693,9 +12693,9 @@
             "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "debug": "2.6.9",
-                "mkdirp": "0.5.1"
+                "async": "^1.5.2",
+                "debug": "^2.2.0",
+                "mkdirp": "0.5.x"
             },
             "dependencies": {
                 "async": {
@@ -12713,7 +12713,7 @@
             "dev": true,
             "requires": {
                 "async": "1.5.2",
-                "is-number-like": "1.0.8"
+                "is-number-like": "^1.0.3"
             },
             "dependencies": {
                 "async": {
@@ -12736,10 +12736,10 @@
             "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.4.3",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12754,11 +12754,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12787,7 +12787,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12798,9 +12798,9 @@
             "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-message-helpers": "2.0.0",
-                "reduce-css-calc": "1.3.0"
+                "postcss": "^5.0.2",
+                "postcss-message-helpers": "^2.0.0",
+                "reduce-css-calc": "^1.2.6"
             }
         },
         "postcss-colormin": {
@@ -12809,9 +12809,9 @@
             "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
             "dev": true,
             "requires": {
-                "colormin": "1.1.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "colormin": "^1.0.5",
+                "postcss": "^5.0.13",
+                "postcss-value-parser": "^3.2.3"
             }
         },
         "postcss-convert-values": {
@@ -12820,8 +12820,8 @@
             "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.11",
+                "postcss-value-parser": "^3.1.2"
             }
         },
         "postcss-custom-properties": {
@@ -12830,8 +12830,8 @@
             "integrity": "sha512-zoiwn4sCiUFbr4KcgcNZLFkR6gVQom647L+z1p/KBVHZ1OYwT87apnS42atJtx6XlX2yI7N5fjXbFixShQO2QQ==",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
-                "postcss": "6.0.19"
+                "balanced-match": "^1.0.0",
+                "postcss": "^6.0.18"
             },
             "dependencies": {
                 "chalk": {
@@ -12840,9 +12840,9 @@
                     "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -12857,9 +12857,9 @@
                     "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.2.0"
                     }
                 },
                 "supports-color": {
@@ -12868,7 +12868,7 @@
                     "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -12879,7 +12879,7 @@
             "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.14"
             }
         },
         "postcss-discard-duplicates": {
@@ -12888,7 +12888,7 @@
             "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             }
         },
         "postcss-discard-empty": {
@@ -12897,7 +12897,7 @@
             "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.14"
             }
         },
         "postcss-discard-overridden": {
@@ -12906,7 +12906,7 @@
             "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.16"
             }
         },
         "postcss-discard-unused": {
@@ -12915,8 +12915,8 @@
             "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "postcss": "^5.0.14",
+                "uniqs": "^2.0.0"
             }
         },
         "postcss-filter-plugins": {
@@ -12925,8 +12925,8 @@
             "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "uniqid": "4.1.1"
+                "postcss": "^5.0.4",
+                "uniqid": "^4.0.0"
             }
         },
         "postcss-load-config": {
@@ -12935,10 +12935,10 @@
             "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
             "dev": true,
             "requires": {
-                "cosmiconfig": "2.2.2",
-                "object-assign": "4.1.1",
-                "postcss-load-options": "1.2.0",
-                "postcss-load-plugins": "2.3.0"
+                "cosmiconfig": "^2.1.0",
+                "object-assign": "^4.1.0",
+                "postcss-load-options": "^1.2.0",
+                "postcss-load-plugins": "^2.3.0"
             }
         },
         "postcss-load-options": {
@@ -12947,8 +12947,8 @@
             "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
             "dev": true,
             "requires": {
-                "cosmiconfig": "2.2.2",
-                "object-assign": "4.1.1"
+                "cosmiconfig": "^2.1.0",
+                "object-assign": "^4.1.0"
             }
         },
         "postcss-load-plugins": {
@@ -12957,8 +12957,8 @@
             "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
             "dev": true,
             "requires": {
-                "cosmiconfig": "2.2.2",
-                "object-assign": "4.1.1"
+                "cosmiconfig": "^2.1.1",
+                "object-assign": "^4.1.0"
             }
         },
         "postcss-loader": {
@@ -12967,10 +12967,10 @@
             "integrity": "sha1-piHqH6KQYqg5cqRvVEhncTAZFus=",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-load-config": "1.2.0"
+                "loader-utils": "^1.0.2",
+                "object-assign": "^4.1.1",
+                "postcss": "^5.2.15",
+                "postcss-load-config": "^1.2.0"
             }
         },
         "postcss-merge-idents": {
@@ -12979,9 +12979,9 @@
             "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.10",
+                "postcss-value-parser": "^3.1.1"
             }
         },
         "postcss-merge-longhand": {
@@ -12990,7 +12990,7 @@
             "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             }
         },
         "postcss-merge-rules": {
@@ -12999,11 +12999,11 @@
             "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-api": "1.6.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3",
-                "vendors": "1.0.1"
+                "browserslist": "^1.5.2",
+                "caniuse-api": "^1.5.2",
+                "postcss": "^5.0.4",
+                "postcss-selector-parser": "^2.2.2",
+                "vendors": "^1.0.0"
             }
         },
         "postcss-message-helpers": {
@@ -13018,9 +13018,9 @@
             "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
             }
         },
         "postcss-minify-gradients": {
@@ -13029,8 +13029,8 @@
             "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.12",
+                "postcss-value-parser": "^3.3.0"
             }
         },
         "postcss-minify-params": {
@@ -13039,10 +13039,10 @@
             "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "uniqs": "2.0.0"
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.2",
+                "postcss-value-parser": "^3.0.2",
+                "uniqs": "^2.0.0"
             }
         },
         "postcss-minify-selectors": {
@@ -13051,10 +13051,10 @@
             "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3"
+                "alphanum-sort": "^1.0.2",
+                "has": "^1.0.1",
+                "postcss": "^5.0.14",
+                "postcss-selector-parser": "^2.0.0"
             }
         },
         "postcss-modules-extract-imports": {
@@ -13063,7 +13063,7 @@
             "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.19"
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "chalk": {
@@ -13072,9 +13072,9 @@
                     "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -13089,9 +13089,9 @@
                     "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.2.0"
                     }
                 },
                 "supports-color": {
@@ -13100,7 +13100,7 @@
                     "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -13111,8 +13111,8 @@
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.19"
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "chalk": {
@@ -13121,9 +13121,9 @@
                     "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -13138,9 +13138,9 @@
                     "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.2.0"
                     }
                 },
                 "supports-color": {
@@ -13149,7 +13149,7 @@
                     "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -13160,8 +13160,8 @@
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.19"
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "chalk": {
@@ -13170,9 +13170,9 @@
                     "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -13187,9 +13187,9 @@
                     "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.2.0"
                     }
                 },
                 "supports-color": {
@@ -13198,7 +13198,7 @@
                     "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -13209,8 +13209,8 @@
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "dev": true,
             "requires": {
-                "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.19"
+                "icss-replace-symbols": "^1.1.0",
+                "postcss": "^6.0.1"
             },
             "dependencies": {
                 "chalk": {
@@ -13219,9 +13219,9 @@
                     "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.3.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -13236,9 +13236,9 @@
                     "integrity": "sha512-f13HRz0HtVwVaEuW6J6cOUCBLFtymhgyLPV7t4QEk2UD3twRI9IluDcQNdzQdBpiixkXj2OmzejhhTbSbDxNTg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.3.2",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.3.0"
+                        "chalk": "^2.3.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.2.0"
                     }
                 },
                 "supports-color": {
@@ -13247,7 +13247,7 @@
                     "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -13258,7 +13258,7 @@
             "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.5"
             }
         },
         "postcss-normalize-url": {
@@ -13267,10 +13267,10 @@
             "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
             "dev": true,
             "requires": {
-                "is-absolute-url": "2.1.0",
-                "normalize-url": "1.9.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "is-absolute-url": "^2.0.0",
+                "normalize-url": "^1.4.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3"
             }
         },
         "postcss-ordered-values": {
@@ -13279,8 +13279,8 @@
             "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.1"
             }
         },
         "postcss-reduce-idents": {
@@ -13289,8 +13289,8 @@
             "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
             }
         },
         "postcss-reduce-initial": {
@@ -13299,7 +13299,7 @@
             "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             }
         },
         "postcss-reduce-transforms": {
@@ -13308,9 +13308,9 @@
             "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.8",
+                "postcss-value-parser": "^3.0.1"
             }
         },
         "postcss-selector-parser": {
@@ -13319,9 +13319,9 @@
             "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
             "dev": true,
             "requires": {
-                "flatten": "1.0.2",
-                "indexes-of": "1.0.1",
-                "uniq": "1.0.1"
+                "flatten": "^1.0.2",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
             }
         },
         "postcss-svgo": {
@@ -13330,10 +13330,10 @@
             "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
             "dev": true,
             "requires": {
-                "is-svg": "2.1.0",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "svgo": "0.7.2"
+                "is-svg": "^2.0.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3",
+                "svgo": "^0.7.0"
             }
         },
         "postcss-unique-selectors": {
@@ -13342,9 +13342,9 @@
             "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
             }
         },
         "postcss-url": {
@@ -13353,13 +13353,13 @@
             "integrity": "sha1-mLMWW+jVkkccsMqt3iwNH4MvEz4=",
             "dev": true,
             "requires": {
-                "directory-encoder": "0.7.2",
-                "js-base64": "2.4.3",
-                "mime": "1.6.0",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "path-is-absolute": "1.0.1",
-                "postcss": "5.2.18"
+                "directory-encoder": "^0.7.2",
+                "js-base64": "^2.1.5",
+                "mime": "^1.2.11",
+                "minimatch": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "path-is-absolute": "^1.0.0",
+                "postcss": "^5.0.0"
             }
         },
         "postcss-value-parser": {
@@ -13374,9 +13374,9 @@
             "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
             }
         },
         "prepend-http": {
@@ -13396,8 +13396,8 @@
             "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
             "dev": true,
             "requires": {
-                "renderkid": "2.0.1",
-                "utila": "0.4.0"
+                "renderkid": "^2.0.1",
+                "utila": "~0.4"
             }
         },
         "prismjs": {
@@ -13405,7 +13405,7 @@
             "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.11.0.tgz",
             "integrity": "sha1-KXrvM+t5Qhv9sZJzpQkspRWXDSk=",
             "requires": {
-                "clipboard": "1.7.1"
+                "clipboard": "^1.7.1"
             }
         },
         "private": {
@@ -13432,7 +13432,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "asap": "2.0.6"
+                "asap": "~2.0.3"
             }
         },
         "promise-inflight": {
@@ -13447,12 +13447,12 @@
             "integrity": "sha1-jlcSPDlquYiJf7Mn/Trtw+c15P4=",
             "dev": true,
             "requires": {
-                "colors": "1.1.2",
-                "pkginfo": "0.4.1",
-                "read": "1.0.7",
-                "revalidator": "0.1.8",
-                "utile": "0.3.0",
-                "winston": "2.1.1"
+                "colors": "^1.1.2",
+                "pkginfo": "0.x.x",
+                "read": "1.0.x",
+                "revalidator": "0.1.x",
+                "utile": "0.3.x",
+                "winston": "2.1.x"
             }
         },
         "proxy-addr": {
@@ -13461,7 +13461,7 @@
             "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
             "dev": true,
             "requires": {
-                "forwarded": "0.1.2",
+                "forwarded": "~0.1.2",
                 "ipaddr.js": "1.6.0"
             }
         },
@@ -13477,7 +13477,7 @@
             "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4"
+                "event-stream": "~3.3.0"
             }
         },
         "pseudomap": {
@@ -13492,11 +13492,11 @@
             "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.1.3",
-                "parse-asn1": "5.1.0",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1"
             }
         },
         "pump": {
@@ -13505,8 +13505,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "pumpify": {
@@ -13515,9 +13515,9 @@
             "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.4",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.5.3",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             }
         },
         "punycode": {
@@ -13550,8 +13550,8 @@
             "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "strict-uri-encode": "1.1.0"
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
             }
         },
         "querystring": {
@@ -13577,8 +13577,8 @@
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -13586,7 +13586,7 @@
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -13594,7 +13594,7 @@
                             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -13604,7 +13604,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -13615,7 +13615,7 @@
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.1.0"
             }
         },
         "randomfill": {
@@ -13624,8 +13624,8 @@
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
-                "randombytes": "2.0.6",
-                "safe-buffer": "5.1.1"
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
             }
         },
         "range-parser": {
@@ -13658,10 +13658,10 @@
             "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
             "dev": true,
             "requires": {
-                "deep-extend": "0.4.2",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "~0.4.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             }
         },
         "read": {
@@ -13670,7 +13670,7 @@
             "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
             "dev": true,
             "requires": {
-                "mute-stream": "0.0.7"
+                "mute-stream": "~0.0.4"
             }
         },
         "read-pkg": {
@@ -13679,9 +13679,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             },
             "dependencies": {
                 "path-type": {
@@ -13690,9 +13690,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -13709,8 +13709,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -13719,8 +13719,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-exists": {
@@ -13729,7 +13729,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 }
             }
@@ -13739,13 +13739,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
             "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readdirp": {
@@ -13753,10 +13753,10 @@
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.5",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "realize-package-specifier": {
@@ -13765,8 +13765,8 @@
             "integrity": "sha1-0N74gpUrjeP2frpekRmWYScfQfQ=",
             "dev": true,
             "requires": {
-                "dezalgo": "1.0.3",
-                "npm-package-arg": "4.2.1"
+                "dezalgo": "^1.0.1",
+                "npm-package-arg": "^4.1.1"
             }
         },
         "recast": {
@@ -13776,9 +13776,9 @@
             "dev": true,
             "requires": {
                 "ast-types": "0.9.6",
-                "esprima": "3.1.3",
-                "private": "0.1.8",
-                "source-map": "0.5.7"
+                "esprima": "~3.1.0",
+                "private": "~0.1.5",
+                "source-map": "~0.5.0"
             },
             "dependencies": {
                 "esprima": {
@@ -13801,7 +13801,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.5.0"
+                "resolve": "^1.1.6"
             }
         },
         "redent": {
@@ -13810,8 +13810,8 @@
             "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
             "dev": true,
             "requires": {
-                "indent-string": "2.1.0",
-                "strip-indent": "1.0.1"
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
             }
         },
         "reduce-css-calc": {
@@ -13820,9 +13820,9 @@
             "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
             "dev": true,
             "requires": {
-                "balanced-match": "0.4.2",
-                "math-expression-evaluator": "1.2.17",
-                "reduce-function-call": "1.0.2"
+                "balanced-match": "^0.4.2",
+                "math-expression-evaluator": "^1.2.14",
+                "reduce-function-call": "^1.0.1"
             },
             "dependencies": {
                 "balanced-match": {
@@ -13839,7 +13839,7 @@
             "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
             "dev": true,
             "requires": {
-                "balanced-match": "0.4.2"
+                "balanced-match": "^0.4.2"
             },
             "dependencies": {
                 "balanced-match": {
@@ -13872,7 +13872,7 @@
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -13881,8 +13881,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "regexpu-core": {
@@ -13891,9 +13891,9 @@
             "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
             "dev": true,
             "requires": {
-                "regenerate": "1.3.3",
-                "regjsgen": "0.2.0",
-                "regjsparser": "0.1.5"
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
             }
         },
         "registry-auth-token": {
@@ -13902,8 +13902,8 @@
             "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
             "dev": true,
             "requires": {
-                "rc": "1.2.5",
-                "safe-buffer": "5.1.1"
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
             }
         },
         "registry-url": {
@@ -13912,7 +13912,7 @@
             "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
             "dev": true,
             "requires": {
-                "rc": "1.2.5"
+                "rc": "^1.0.1"
             }
         },
         "regjsgen": {
@@ -13927,7 +13927,7 @@
             "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
             "dev": true,
             "requires": {
-                "jsesc": "0.5.0"
+                "jsesc": "~0.5.0"
             }
         },
         "relateurl": {
@@ -13947,11 +13947,11 @@
             "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-converter": "0.1.4",
-                "htmlparser2": "3.3.0",
-                "strip-ansi": "3.0.1",
-                "utila": "0.3.3"
+                "css-select": "^1.1.0",
+                "dom-converter": "~0.1",
+                "htmlparser2": "~3.3.0",
+                "strip-ansi": "^3.0.0",
+                "utila": "~0.3"
             },
             "dependencies": {
                 "utila": {
@@ -13978,7 +13978,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "replace": {
@@ -13987,9 +13987,9 @@
             "integrity": "sha1-YAgXIRiGWFlatqeU63/ty0yNOcc=",
             "dev": true,
             "requires": {
-                "colors": "0.5.1",
-                "minimatch": "0.2.14",
-                "nomnom": "1.6.2"
+                "colors": "0.5.x",
+                "minimatch": "~0.2.9",
+                "nomnom": "1.6.x"
             },
             "dependencies": {
                 "colors": {
@@ -14010,8 +14010,8 @@
                     "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 }
             }
@@ -14022,28 +14022,28 @@
             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.6.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.1.4",
-                "har-validator": "4.2.1",
-                "hawk": "3.1.3",
-                "http-signature": "1.1.1",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "0.2.0",
-                "qs": "6.4.0",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
+                "aws-sign2": "~0.6.0",
+                "aws4": "^1.2.1",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.0",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.1.1",
+                "har-validator": "~4.2.1",
+                "hawk": "~3.1.3",
+                "http-signature": "~1.1.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.7",
+                "oauth-sign": "~0.8.1",
+                "performance-now": "^0.2.0",
+                "qs": "~6.4.0",
+                "safe-buffer": "^5.0.1",
+                "stringstream": "~0.0.4",
+                "tough-cookie": "~2.3.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.0.0"
             }
         },
         "require-directory": {
@@ -14076,7 +14076,7 @@
             "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-cwd": {
@@ -14085,7 +14085,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "3.0.0"
+                "resolve-from": "^3.0.0"
             }
         },
         "resolve-from": {
@@ -14106,8 +14106,8 @@
             "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "minimatch": "3.0.4"
+                "debug": "^2.2.0",
+                "minimatch": "^3.0.2"
             }
         },
         "ret": {
@@ -14128,7 +14128,7 @@
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "dev": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -14137,7 +14137,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "ripemd160": {
@@ -14146,8 +14146,8 @@
             "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
             "dev": true,
             "requires": {
-                "hash-base": "2.0.2",
-                "inherits": "2.0.3"
+                "hash-base": "^2.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "rollup": {
@@ -14162,9 +14162,9 @@
             "integrity": "sha1-hZdzGaO/VHUKnXX7kJx+UfWaLaQ=",
             "dev": true,
             "requires": {
-                "acorn": "4.0.13",
-                "magic-string": "0.22.4",
-                "rollup-pluginutils": "2.0.1"
+                "acorn": "4.x",
+                "magic-string": "^0.22.4",
+                "rollup-pluginutils": "^2.0.1"
             },
             "dependencies": {
                 "acorn": {
@@ -14181,11 +14181,11 @@
             "integrity": "sha512-mg+WuD+jlwoo8bJtW3Mvx7Tz6TsIdMsdhuvCnDMoyjh0oxsVgsjB/N0X984RJCWwc5IIiqNVJhXeeITcc73++A==",
             "dev": true,
             "requires": {
-                "acorn": "5.5.0",
-                "estree-walker": "0.5.1",
-                "magic-string": "0.22.4",
-                "resolve": "1.5.0",
-                "rollup-pluginutils": "2.0.1"
+                "acorn": "^5.2.1",
+                "estree-walker": "^0.5.0",
+                "magic-string": "^0.22.4",
+                "resolve": "^1.4.0",
+                "rollup-pluginutils": "^2.0.1"
             },
             "dependencies": {
                 "estree-walker": {
@@ -14229,9 +14229,9 @@
             "integrity": "sha512-qJLXJ1aASV6p8SrEfRdQdHmb5OQmqXyIWIdVGcju8QFzftSsHcuL554Vy+n8mr0fZCC+ksO6aWJ7TAVl2F+Qwg==",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1",
-                "is-module": "1.0.0",
-                "resolve": "1.5.0"
+                "builtin-modules": "^1.1.0",
+                "is-module": "^1.0.0",
+                "resolve": "^1.1.6"
             }
         },
         "rollup-pluginutils": {
@@ -14240,8 +14240,8 @@
             "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
             "dev": true,
             "requires": {
-                "estree-walker": "0.3.1",
-                "micromatch": "2.3.11"
+                "estree-walker": "^0.3.0",
+                "micromatch": "^2.3.11"
             }
         },
         "run-queue": {
@@ -14250,7 +14250,7 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0"
+                "aproba": "^1.1.1"
             }
         },
         "rx": {
@@ -14278,7 +14278,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "sander": {
@@ -14287,10 +14287,10 @@
             "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
             "dev": true,
             "requires": {
-                "es6-promise": "3.3.1",
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "es6-promise": "^3.1.2",
+                "graceful-fs": "^4.1.3",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.2"
             }
         },
         "sass-graph": {
@@ -14299,10 +14299,10 @@
             "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "lodash": "4.17.5",
-                "scss-tokenizer": "0.2.3",
-                "yargs": "7.1.0"
+                "glob": "^7.0.0",
+                "lodash": "^4.0.0",
+                "scss-tokenizer": "^0.2.3",
+                "yargs": "^7.0.0"
             }
         },
         "sass-loader": {
@@ -14311,11 +14311,11 @@
             "integrity": "sha512-JoiyD00Yo1o61OJsoP2s2kb19L1/Y2p3QFcCdWdF6oomBGKVYuZyqHWemRBfQ2uGYsk+CH3eCguXNfpjzlcpaA==",
             "dev": true,
             "requires": {
-                "clone-deep": "2.0.2",
-                "loader-utils": "1.1.0",
-                "lodash.tail": "4.1.1",
-                "neo-async": "2.5.0",
-                "pify": "3.0.0"
+                "clone-deep": "^2.0.1",
+                "loader-utils": "^1.0.1",
+                "lodash.tail": "^4.1.1",
+                "neo-async": "^2.5.0",
+                "pify": "^3.0.0"
             }
         },
         "sauce-connect-launcher": {
@@ -14324,11 +14324,11 @@
             "integrity": "sha1-0vkxrXro/avxlopEDnsgQXrKf4Y=",
             "dev": true,
             "requires": {
-                "adm-zip": "0.4.7",
-                "async": "2.6.0",
-                "https-proxy-agent": "1.0.0",
-                "lodash": "4.17.5",
-                "rimraf": "2.6.2"
+                "adm-zip": "~0.4.3",
+                "async": "^2.1.2",
+                "https-proxy-agent": "~1.0.0",
+                "lodash": "^4.16.6",
+                "rimraf": "^2.5.4"
             }
         },
         "saucelabs": {
@@ -14337,7 +14337,7 @@
             "integrity": "sha1-uTSpr52ih0s/QKrh/N5QpEZvXzg=",
             "dev": true,
             "requires": {
-                "https-proxy-agent": "1.0.0"
+                "https-proxy-agent": "^1.0.0"
             }
         },
         "sax": {
@@ -14352,7 +14352,7 @@
             "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2"
+                "ajv": "^5.0.0"
             }
         },
         "scss-tokenizer": {
@@ -14361,8 +14361,8 @@
             "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
             "dev": true,
             "requires": {
-                "js-base64": "2.4.3",
-                "source-map": "0.4.4"
+                "js-base64": "^2.1.8",
+                "source-map": "^0.4.2"
             },
             "dependencies": {
                 "source-map": {
@@ -14371,7 +14371,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -14409,7 +14409,7 @@
             "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
             "dev": true,
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.0.3"
             }
         },
         "send": {
@@ -14419,18 +14419,18 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.1",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.6.2",
+                "http-errors": "~1.6.2",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.3.1"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.3.1"
             },
             "dependencies": {
                 "mime": {
@@ -14453,13 +14453,13 @@
             "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.4",
                 "batch": "0.6.1",
                 "debug": "2.6.9",
-                "escape-html": "1.0.3",
-                "http-errors": "1.6.2",
-                "mime-types": "2.1.18",
-                "parseurl": "1.3.2"
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
             }
         },
         "serve-static": {
@@ -14468,9 +14468,9 @@
             "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
             "dev": true,
             "requires": {
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
                 "send": "0.16.1"
             }
         },
@@ -14492,7 +14492,7 @@
             "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
             "dev": true,
             "requires": {
-                "to-object-path": "0.3.0"
+                "to-object-path": "^0.3.0"
             }
         },
         "set-immediate-shim": {
@@ -14506,10 +14506,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -14518,7 +14518,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -14541,8 +14541,8 @@
             "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "shallow-clone": {
@@ -14551,9 +14551,9 @@
             "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
             "dev": true,
             "requires": {
-                "is-extendable": "0.1.1",
-                "kind-of": "5.1.0",
-                "mixin-object": "2.0.1"
+                "is-extendable": "^0.1.1",
+                "kind-of": "^5.0.0",
+                "mixin-object": "^2.0.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -14570,7 +14570,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -14585,10 +14585,10 @@
             "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
             "dev": true,
             "requires": {
-                "array-filter": "0.0.1",
-                "array-map": "0.0.0",
-                "array-reduce": "0.0.0",
-                "jsonify": "0.0.0"
+                "array-filter": "~0.0.0",
+                "array-map": "~0.0.0",
+                "array-reduce": "~0.0.0",
+                "jsonify": "~0.0.0"
             }
         },
         "shelljs": {
@@ -14597,9 +14597,9 @@
             "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "interpret": "1.1.0",
-                "rechoir": "0.6.2"
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
             }
         },
         "sigmund": {
@@ -14620,7 +14620,7 @@
             "integrity": "sha1-IglwbxyFCp8dENDYQJGLRvJuG8k=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9"
+                "debug": "^2.2.0"
             }
         },
         "slash": {
@@ -14635,14 +14635,14 @@
             "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.1",
-                "use": "2.0.2"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^2.0.0"
             },
             "dependencies": {
                 "define-property": {
@@ -14669,7 +14669,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -14678,7 +14678,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -14689,7 +14689,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -14698,7 +14698,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -14709,9 +14709,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -14734,9 +14734,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -14745,7 +14745,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "isobject": {
@@ -14762,7 +14762,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             }
         },
         "sntp": {
@@ -14771,7 +14771,7 @@
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "socket.io": {
@@ -14922,8 +14922,8 @@
             "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
             "dev": true,
             "requires": {
-                "faye-websocket": "0.10.0",
-                "uuid": "2.0.3"
+                "faye-websocket": "^0.10.0",
+                "uuid": "^2.0.2"
             },
             "dependencies": {
                 "uuid": {
@@ -14940,12 +14940,12 @@
             "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
+                "debug": "^2.6.6",
                 "eventsource": "0.1.6",
-                "faye-websocket": "0.11.1",
-                "inherits": "2.0.3",
-                "json3": "3.3.2",
-                "url-parse": "1.2.0"
+                "faye-websocket": "~0.11.0",
+                "inherits": "^2.0.1",
+                "json3": "^3.3.2",
+                "url-parse": "^1.1.8"
             },
             "dependencies": {
                 "faye-websocket": {
@@ -14954,7 +14954,7 @@
                     "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
                     "dev": true,
                     "requires": {
-                        "websocket-driver": "0.7.0"
+                        "websocket-driver": ">=0.5.1"
                     }
                 }
             }
@@ -14965,10 +14965,10 @@
             "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "minimist": "1.2.0",
-                "sander": "0.5.1",
-                "sourcemap-codec": "1.4.0"
+                "buffer-crc32": "^0.2.5",
+                "minimist": "^1.2.0",
+                "sander": "^0.5.0",
+                "sourcemap-codec": "^1.3.0"
             }
         },
         "sort-keys": {
@@ -14977,7 +14977,7 @@
             "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
             "dev": true,
             "requires": {
-                "is-plain-obj": "1.1.0"
+                "is-plain-obj": "^1.0.0"
             }
         },
         "source-list-map": {
@@ -14997,9 +14997,9 @@
             "integrity": "sha512-MYbFX9DYxmTQFfy2v8FC1XZwpwHKYxg3SK8Wb7VPBKuhDjz8gi9re2819MsG4p49HDyiOSUKlmZ+nQBArW5CGw==",
             "dev": true,
             "requires": {
-                "async": "2.6.0",
-                "loader-utils": "0.2.17",
-                "source-map": "0.6.1"
+                "async": "^2.5.0",
+                "loader-utils": "~0.2.2",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
                 "loader-utils": {
@@ -15008,10 +15008,10 @@
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1",
-                        "object-assign": "4.1.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0",
+                        "object-assign": "^4.0.1"
                     }
                 }
             }
@@ -15022,11 +15022,11 @@
             "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
             "dev": true,
             "requires": {
-                "atob": "2.0.3",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.0.0",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -15034,7 +15034,7 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
             "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "^0.6.0"
             }
         },
         "source-map-url": {
@@ -15049,7 +15049,7 @@
             "integrity": "sha512-66s3CwUASiYGiwQxkr34IctPs/LDkaJ8qNqVK6bBektymq3Sx1rX9qDZ8MNXFwiXqKuM3JYwzG3NAhI1ivqkjA==",
             "dev": true,
             "requires": {
-                "vlq": "1.0.0"
+                "vlq": "^1.0.0"
             },
             "dependencies": {
                 "vlq": {
@@ -15066,8 +15066,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -15082,8 +15082,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -15098,12 +15098,12 @@
             "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "handle-thing": "1.2.5",
-                "http-deceiver": "1.2.7",
-                "safe-buffer": "5.1.1",
-                "select-hose": "2.0.0",
-                "spdy-transport": "2.0.20"
+                "debug": "^2.6.8",
+                "handle-thing": "^1.2.5",
+                "http-deceiver": "^1.2.7",
+                "safe-buffer": "^5.0.1",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^2.0.18"
             }
         },
         "spdy-transport": {
@@ -15112,13 +15112,13 @@
             "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "detect-node": "2.0.3",
-                "hpack.js": "2.1.6",
-                "obuf": "1.1.1",
-                "readable-stream": "2.3.5",
-                "safe-buffer": "5.1.1",
-                "wbuf": "1.7.2"
+                "debug": "^2.6.8",
+                "detect-node": "^2.0.3",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.1",
+                "readable-stream": "^2.2.9",
+                "safe-buffer": "^5.0.1",
+                "wbuf": "^1.7.2"
             }
         },
         "split": {
@@ -15127,7 +15127,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -15136,7 +15136,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -15151,14 +15151,14 @@
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -15175,7 +15175,7 @@
             "integrity": "sha512-UnEAgMZa15973iH7cUi0AHjJn1ACDIkaMyZILoqwN6yzt+4P81I8tBc5Hl+qwi5auMplZtPQsHrPBR5vJLcQtQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.1.1"
             }
         },
         "stack-trace": {
@@ -15190,8 +15190,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -15200,7 +15200,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -15209,7 +15209,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -15218,7 +15218,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -15229,7 +15229,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -15238,7 +15238,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -15249,9 +15249,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -15274,7 +15274,7 @@
             "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.1"
             }
         },
         "stream-browserify": {
@@ -15283,8 +15283,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "stream-combiner": {
@@ -15293,7 +15293,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-each": {
@@ -15302,8 +15302,8 @@
             "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "stream-http": {
@@ -15312,11 +15312,11 @@
             "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "3.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "to-arraybuffer": "1.0.1",
-                "xtend": "4.0.1"
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.3",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "stream-shift": {
@@ -15331,8 +15331,8 @@
             "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
             "dev": true,
             "requires": {
-                "commander": "2.14.1",
-                "limiter": "1.1.2"
+                "commander": "^2.2.0",
+                "limiter": "^1.0.5"
             }
         },
         "strict-uri-encode": {
@@ -15347,9 +15347,9 @@
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
         },
         "string.prototype.padend": {
@@ -15358,9 +15358,9 @@
             "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.10.0",
-                "function-bind": "1.1.1"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.4.3",
+                "function-bind": "^1.0.2"
             }
         },
         "string_decoder": {
@@ -15368,7 +15368,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
@@ -15383,7 +15383,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -15392,7 +15392,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-eof": {
@@ -15407,7 +15407,7 @@
             "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
             "dev": true,
             "requires": {
-                "get-stdin": "4.0.1"
+                "get-stdin": "^4.0.1"
             }
         },
         "strip-json-comments": {
@@ -15422,7 +15422,7 @@
             "integrity": "sha1-dFMzhM9pjHEEx5URULSXF63C87s=",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0"
+                "loader-utils": "^1.0.2"
             }
         },
         "stylus": {
@@ -15431,12 +15431,12 @@
             "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
             "dev": true,
             "requires": {
-                "css-parse": "1.7.0",
-                "debug": "2.6.9",
-                "glob": "7.0.6",
-                "mkdirp": "0.5.1",
-                "sax": "0.5.8",
-                "source-map": "0.1.43"
+                "css-parse": "1.7.x",
+                "debug": "*",
+                "glob": "7.0.x",
+                "mkdirp": "0.5.x",
+                "sax": "0.5.x",
+                "source-map": "0.1.x"
             },
             "dependencies": {
                 "glob": {
@@ -15445,12 +15445,12 @@
                     "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "sax": {
@@ -15465,7 +15465,7 @@
                     "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -15476,9 +15476,9 @@
             "integrity": "sha512-+VomPdZ6a0razP+zinir61yZgpw2NfljeSsdUF5kJuEzlo3khXhY19Fn6l8QQz1GRJGtMCo8nG5C04ePyV7SUA==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "lodash.clonedeep": "4.5.0",
-                "when": "3.6.4"
+                "loader-utils": "^1.0.2",
+                "lodash.clonedeep": "^4.5.0",
+                "when": "~3.6.x"
             }
         },
         "subarg": {
@@ -15487,7 +15487,7 @@
             "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
             "dev": true,
             "requires": {
-                "minimist": "1.2.0"
+                "minimist": "^1.1.0"
             }
         },
         "supports-color": {
@@ -15496,7 +15496,7 @@
             "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
             "dev": true,
             "requires": {
-                "has-flag": "2.0.0"
+                "has-flag": "^2.0.0"
             }
         },
         "suppress-chunks-webpack-plugin": {
@@ -15505,8 +15505,8 @@
             "integrity": "sha1-RRaUIZ9SSkdNT+rzdMLkA7LKPYU=",
             "dev": true,
             "requires": {
-                "core-js": "2.5.3",
-                "lodash": "4.17.5"
+                "core-js": "^2.4.1",
+                "lodash": "^4.17.2"
             }
         },
         "svgo": {
@@ -15515,13 +15515,13 @@
             "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
             "dev": true,
             "requires": {
-                "coa": "1.0.4",
-                "colors": "1.1.2",
-                "csso": "2.3.2",
-                "js-yaml": "3.7.0",
-                "mkdirp": "0.5.1",
-                "sax": "1.2.4",
-                "whet.extend": "0.9.9"
+                "coa": "~1.0.1",
+                "colors": "~1.1.2",
+                "csso": "~2.3.1",
+                "js-yaml": "~3.7.0",
+                "mkdirp": "~0.5.1",
+                "sax": "~1.2.1",
+                "whet.extend": "~0.9.9"
             }
         },
         "symbol-observable": {
@@ -15541,9 +15541,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "tar-stream": {
@@ -15552,10 +15552,10 @@
             "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
             "dev": true,
             "requires": {
-                "bl": "1.2.1",
-                "end-of-stream": "1.4.1",
-                "readable-stream": "2.3.5",
-                "xtend": "4.0.1"
+                "bl": "^1.0.0",
+                "end-of-stream": "^1.0.0",
+                "readable-stream": "^2.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "term-size": {
@@ -15564,7 +15564,7 @@
             "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
             "dev": true,
             "requires": {
-                "execa": "0.7.0"
+                "execa": "^0.7.0"
             }
         },
         "tether": {
@@ -15578,7 +15578,7 @@
             "integrity": "sha1-NOrJ0Ezy2xVKBzOBwJKfv8oOuDo=",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0"
+                "loader-utils": "^1.1.0"
             }
         },
         "tfunk": {
@@ -15587,8 +15587,8 @@
             "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "object-path": "0.9.2"
+                "chalk": "^1.1.1",
+                "object-path": "^0.9.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -15603,11 +15603,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -15630,8 +15630,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "thunky": {
@@ -15658,7 +15658,7 @@
             "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
             "dev": true,
             "requires": {
-                "setimmediate": "1.0.5"
+                "setimmediate": "^1.0.4"
             }
         },
         "tiny-emitter": {
@@ -15673,7 +15673,7 @@
             "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.1"
             }
         },
         "to-array": {
@@ -15700,7 +15700,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "to-regex": {
@@ -15709,10 +15709,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -15721,8 +15721,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             },
             "dependencies": {
                 "is-number": {
@@ -15731,7 +15731,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 }
             }
@@ -15748,7 +15748,7 @@
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tree-kill": {
@@ -15775,7 +15775,7 @@
             "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
             "dev": true,
             "requires": {
-                "glob": "6.0.4"
+                "glob": "^6.0.4"
             },
             "dependencies": {
                 "glob": {
@@ -15784,11 +15784,11 @@
                     "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 }
             }
@@ -15799,16 +15799,16 @@
             "integrity": "sha1-u9KOOK9Kqj6WB2xGbhsiAZfBo84=",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "chalk": "2.2.2",
-                "diff": "3.5.0",
-                "make-error": "1.3.4",
-                "minimist": "1.2.0",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.4.18",
-                "tsconfig": "6.0.0",
-                "v8flags": "3.0.2",
-                "yn": "2.0.0"
+                "arrify": "^1.0.0",
+                "chalk": "^2.0.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.0",
+                "tsconfig": "^6.0.0",
+                "v8flags": "^3.0.0",
+                "yn": "^2.0.0"
             },
             "dependencies": {
                 "source-map": {
@@ -15823,7 +15823,7 @@
                     "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7"
+                        "source-map": "^0.5.6"
                     }
                 }
             }
@@ -15834,8 +15834,8 @@
             "integrity": "sha1-aw6DdgA9evGGT434+J3QBZ/80DI=",
             "dev": true,
             "requires": {
-                "strip-bom": "3.0.0",
-                "strip-json-comments": "2.0.1"
+                "strip-bom": "^3.0.0",
+                "strip-json-comments": "^2.0.0"
             },
             "dependencies": {
                 "strip-bom": {
@@ -15852,10 +15852,10 @@
             "integrity": "sha1-tZXbFrI2chgk7u2ouyYjZbR+8zQ=",
             "dev": true,
             "requires": {
-                "minimist": "1.2.0",
-                "mkdirp": "0.5.1",
-                "source-map": "0.5.7",
-                "source-map-support": "0.4.18"
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map": "^0.5.6",
+                "source-map-support": "^0.4.2"
             },
             "dependencies": {
                 "source-map": {
@@ -15870,7 +15870,7 @@
                     "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7"
+                        "source-map": "^0.5.6"
                     }
                 }
             }
@@ -15886,16 +15886,16 @@
             "integrity": "sha1-wl4NDJL6EgHCvDDoROCOaCtPNVI=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "colors": "1.1.2",
-                "commander": "2.14.1",
-                "diff": "3.5.0",
-                "glob": "7.1.2",
-                "minimatch": "3.0.4",
-                "resolve": "1.5.0",
-                "semver": "5.5.0",
-                "tslib": "1.9.0",
-                "tsutils": "2.22.2"
+                "babel-code-frame": "^6.22.0",
+                "colors": "^1.1.2",
+                "commander": "^2.9.0",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.7.1",
+                "tsutils": "^2.8.1"
             }
         },
         "tslint-defocus": {
@@ -15904,9 +15904,9 @@
             "integrity": "sha1-8yNJhQ91MI5uvwD5DGn/zbJ55t0=",
             "dev": true,
             "requires": {
-                "es6-shim": "0.35.3",
-                "tslint": "5.7.0",
-                "typescript": "2.4.2"
+                "es6-shim": "^0.35.0",
+                "tslint": "^5.4.3",
+                "typescript": "^2.4.1"
             }
         },
         "tsutils": {
@@ -15915,7 +15915,7 @@
             "integrity": "sha512-u06FUSulCJ+Y8a2ftuqZN6kIGqdP2yJjUPEngXqmdPND4UQfb04igcotH+dw+IFr417yP6muCLE8/5/Qlfnx0w==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.8.1"
             }
         },
         "tty-browserify": {
@@ -15930,7 +15930,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -15947,7 +15947,7 @@
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.18"
+                "mime-types": "~2.1.18"
             }
         },
         "typedarray": {
@@ -15974,8 +15974,8 @@
             "integrity": "sha512-7rdn/bDOG1ElSTPdh7AI5TCjLv63ZD4k8BBadN3ssIkhlaQL2c0yRxmXCyOYhZK0wZTgGgUSnYQ4CGu+Jos5cA==",
             "dev": true,
             "requires": {
-                "commander": "2.14.1",
-                "source-map": "0.6.1"
+                "commander": "~2.14.1",
+                "source-map": "~0.6.1"
             }
         },
         "uglify-to-browserify": {
@@ -15991,14 +15991,14 @@
             "integrity": "sha512-XG8/QmR1pyPeE1kj2aigo5kos8umefB31zW+PMvAAytHSB0T/vQvN6sqt8+Sh+y0b0A7zlmxNi2dzRnj0wcqGA==",
             "dev": true,
             "requires": {
-                "cacache": "10.0.4",
-                "find-cache-dir": "1.0.0",
-                "schema-utils": "0.4.5",
-                "serialize-javascript": "1.4.0",
-                "source-map": "0.6.1",
-                "uglify-es": "3.3.9",
-                "webpack-sources": "1.1.0",
-                "worker-farm": "1.5.4"
+                "cacache": "^10.0.1",
+                "find-cache-dir": "^1.0.0",
+                "schema-utils": "^0.4.2",
+                "serialize-javascript": "^1.4.0",
+                "source-map": "^0.6.1",
+                "uglify-es": "^3.3.4",
+                "webpack-sources": "^1.1.0",
+                "worker-farm": "^1.5.2"
             },
             "dependencies": {
                 "ajv": {
@@ -16007,9 +16007,9 @@
                     "integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "1.1.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 },
                 "commander": {
@@ -16024,8 +16024,8 @@
                     "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
                     "dev": true,
                     "requires": {
-                        "ajv": "6.2.1",
-                        "ajv-keywords": "3.1.0"
+                        "ajv": "^6.1.0",
+                        "ajv-keywords": "^3.1.0"
                     }
                 },
                 "uglify-es": {
@@ -16058,8 +16058,8 @@
             "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "sprintf-js": "^1.0.3",
+                "util-deprecate": "^1.0.2"
             }
         },
         "union-value": {
@@ -16068,10 +16068,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -16080,7 +16080,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -16089,10 +16089,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -16109,7 +16109,7 @@
             "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
             "dev": true,
             "requires": {
-                "macaddress": "0.2.8"
+                "macaddress": "^0.2.8"
             }
         },
         "uniqs": {
@@ -16124,7 +16124,7 @@
             "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
             "dev": true,
             "requires": {
-                "unique-slug": "2.0.0"
+                "unique-slug": "^2.0.0"
             }
         },
         "unique-slug": {
@@ -16133,7 +16133,7 @@
             "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
             "dev": true,
             "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
             }
         },
         "unique-string": {
@@ -16142,7 +16142,7 @@
             "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
             "dev": true,
             "requires": {
-                "crypto-random-string": "1.0.0"
+                "crypto-random-string": "^1.0.0"
             }
         },
         "universalify": {
@@ -16163,8 +16163,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -16173,9 +16173,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -16221,15 +16221,15 @@
             "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
             "dev": true,
             "requires": {
-                "boxen": "1.3.0",
-                "chalk": "2.2.2",
-                "configstore": "3.1.1",
-                "import-lazy": "2.1.0",
-                "is-installed-globally": "0.1.0",
-                "is-npm": "1.0.0",
-                "latest-version": "3.1.0",
-                "semver-diff": "2.1.0",
-                "xdg-basedir": "3.0.0"
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "upper-case": {
@@ -16268,8 +16268,8 @@
             "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "mime": "1.3.6"
+                "loader-utils": "^1.0.2",
+                "mime": "1.3.x"
             },
             "dependencies": {
                 "mime": {
@@ -16286,8 +16286,8 @@
             "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
             "dev": true,
             "requires": {
-                "querystringify": "1.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "~1.0.0",
+                "requires-port": "~1.0.0"
             },
             "dependencies": {
                 "querystringify": {
@@ -16304,7 +16304,7 @@
             "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
             "dev": true,
             "requires": {
-                "prepend-http": "1.0.4"
+                "prepend-http": "^1.0.1"
             }
         },
         "use": {
@@ -16313,9 +16313,9 @@
             "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "lazy-cache": "2.0.2"
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "lazy-cache": "^2.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -16324,7 +16324,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -16333,7 +16333,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -16342,7 +16342,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -16353,7 +16353,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -16362,7 +16362,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -16373,9 +16373,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "isobject": {
@@ -16396,7 +16396,7 @@
                     "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
                     "dev": true,
                     "requires": {
-                        "set-getter": "0.1.0"
+                        "set-getter": "^0.1.0"
                     }
                 }
             }
@@ -16407,8 +16407,8 @@
             "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.1",
-                "tmp": "0.0.31"
+                "lru-cache": "4.1.x",
+                "tmp": "0.0.x"
             }
         },
         "util": {
@@ -16445,12 +16445,12 @@
             "integrity": "sha1-E1LDQOuCDk2N26A5pPv6oy7U7zo=",
             "dev": true,
             "requires": {
-                "async": "0.9.2",
-                "deep-equal": "0.2.2",
-                "i": "0.3.6",
-                "mkdirp": "0.5.1",
-                "ncp": "1.0.1",
-                "rimraf": "2.6.2"
+                "async": "~0.9.0",
+                "deep-equal": "~0.2.1",
+                "i": "0.3.x",
+                "mkdirp": "0.x.x",
+                "ncp": "1.0.x",
+                "rimraf": "2.x.x"
             },
             "dependencies": {
                 "async": {
@@ -16492,7 +16492,7 @@
             "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "validate-npm-package-license": {
@@ -16501,8 +16501,8 @@
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "vargs": {
@@ -16529,9 +16529,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -16575,9 +16575,9 @@
             "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
             "dev": true,
             "requires": {
-                "chokidar": "2.0.2",
-                "graceful-fs": "4.1.11",
-                "neo-async": "2.5.0"
+                "chokidar": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "neo-async": "^2.5.0"
             },
             "dependencies": {
                 "anymatch": {
@@ -16608,18 +16608,18 @@
                     "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "kind-of": "6.0.2",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.1",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "kind-of": "^6.0.2",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -16628,7 +16628,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -16648,18 +16648,18 @@
                     "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "2.0.0",
-                        "async-each": "1.0.1",
-                        "braces": "2.3.1",
-                        "fsevents": "1.1.3",
-                        "glob-parent": "3.1.0",
-                        "inherits": "2.0.3",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "4.0.0",
-                        "normalize-path": "2.1.1",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.1.0",
-                        "upath": "1.0.4"
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.0",
+                        "braces": "^2.3.0",
+                        "fsevents": "^1.0.0",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^2.1.1",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0",
+                        "upath": "^1.0.0"
                     }
                 },
                 "expand-brackets": {
@@ -16800,7 +16800,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -16809,7 +16809,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -16820,7 +16820,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -16829,7 +16829,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -16887,19 +16887,19 @@
                     "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.1",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.1",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     }
                 }
             }
@@ -16910,7 +16910,7 @@
             "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
             "dev": true,
             "requires": {
-                "minimalistic-assert": "1.0.0"
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "wd": {
@@ -16922,7 +16922,7 @@
                 "archiver": "1.3.0",
                 "async": "2.0.1",
                 "lodash": "4.16.2",
-                "mkdirp": "0.5.1",
+                "mkdirp": "^0.5.1",
                 "q": "1.4.1",
                 "request": "2.79.0",
                 "underscore.string": "3.3.4",
@@ -16956,11 +16956,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "har-validator": {
@@ -16969,10 +16969,10 @@
                     "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "commander": "2.14.1",
-                        "is-my-json-valid": "2.17.2",
-                        "pinkie-promise": "2.0.1"
+                        "chalk": "^1.1.1",
+                        "commander": "^2.9.0",
+                        "is-my-json-valid": "^2.12.4",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "lodash": {
@@ -16999,26 +16999,26 @@
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.18",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.2.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.11.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~2.0.6",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "qs": "~6.3.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "supports-color": {
@@ -17046,28 +17046,28 @@
             "integrity": "sha512-OsHT3D0W0KmPPh60tC7asNnOmST6bKTiR90UyEdT9QYoaJ4OYN4Gg7WK1k3VxHK07ZoiYWPsKvlS/gAjwL/vRA==",
             "dev": true,
             "requires": {
-                "acorn": "5.5.0",
-                "acorn-dynamic-import": "2.0.2",
-                "ajv": "5.5.2",
-                "ajv-keywords": "2.1.1",
-                "async": "2.6.0",
-                "enhanced-resolve": "3.4.1",
-                "escope": "3.6.0",
-                "interpret": "1.1.0",
-                "json-loader": "0.5.7",
-                "json5": "0.5.1",
-                "loader-runner": "2.3.0",
-                "loader-utils": "1.1.0",
-                "memory-fs": "0.4.1",
-                "mkdirp": "0.5.1",
-                "node-libs-browser": "2.1.0",
-                "source-map": "0.5.7",
-                "supports-color": "4.5.0",
-                "tapable": "0.2.8",
-                "uglifyjs-webpack-plugin": "0.4.6",
-                "watchpack": "1.5.0",
-                "webpack-sources": "1.1.0",
-                "yargs": "8.0.2"
+                "acorn": "^5.0.0",
+                "acorn-dynamic-import": "^2.0.0",
+                "ajv": "^5.1.5",
+                "ajv-keywords": "^2.0.0",
+                "async": "^2.1.2",
+                "enhanced-resolve": "^3.4.0",
+                "escope": "^3.6.0",
+                "interpret": "^1.0.0",
+                "json-loader": "^0.5.4",
+                "json5": "^0.5.1",
+                "loader-runner": "^2.3.0",
+                "loader-utils": "^1.1.0",
+                "memory-fs": "~0.4.1",
+                "mkdirp": "~0.5.0",
+                "node-libs-browser": "^2.0.0",
+                "source-map": "^0.5.3",
+                "supports-color": "^4.2.1",
+                "tapable": "^0.2.7",
+                "uglifyjs-webpack-plugin": "^0.4.6",
+                "watchpack": "^1.4.0",
+                "webpack-sources": "^1.0.1",
+                "yargs": "^8.0.2"
             },
             "dependencies": {
                 "ajv-keywords": {
@@ -17094,8 +17094,8 @@
                     "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                     "dev": true,
                     "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                     }
                 },
@@ -17105,10 +17105,10 @@
                     "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "strip-bom": "3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "os-locale": {
@@ -17117,9 +17117,9 @@
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     }
                 },
                 "path-type": {
@@ -17128,7 +17128,7 @@
                     "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
                     "dev": true,
                     "requires": {
-                        "pify": "2.3.0"
+                        "pify": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -17143,9 +17143,9 @@
                     "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "2.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "2.0.0"
+                        "load-json-file": "^2.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^2.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -17154,8 +17154,8 @@
                     "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
                     "dev": true,
                     "requires": {
-                        "find-up": "2.1.0",
-                        "read-pkg": "2.0.0"
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^2.0.0"
                     }
                 },
                 "source-map": {
@@ -17170,8 +17170,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     },
                     "dependencies": {
                         "is-fullwidth-code-point": {
@@ -17186,7 +17186,7 @@
                             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "ansi-regex": "^3.0.0"
                             }
                         }
                     }
@@ -17203,9 +17203,9 @@
                     "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
                     },
                     "dependencies": {
                         "yargs": {
@@ -17214,9 +17214,9 @@
                             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                             "dev": true,
                             "requires": {
-                                "camelcase": "1.2.1",
-                                "cliui": "2.1.0",
-                                "decamelize": "1.2.0",
+                                "camelcase": "^1.0.2",
+                                "cliui": "^2.1.0",
+                                "decamelize": "^1.0.0",
                                 "window-size": "0.1.0"
                             }
                         }
@@ -17228,9 +17228,9 @@
                     "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-js": "2.8.29",
-                        "webpack-sources": "1.1.0"
+                        "source-map": "^0.5.6",
+                        "uglify-js": "^2.8.29",
+                        "webpack-sources": "^1.0.1"
                     }
                 },
                 "which-module": {
@@ -17251,19 +17251,19 @@
                     "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "2.1.0",
-                        "read-pkg-up": "2.0.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "7.0.0"
+                        "camelcase": "^4.1.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "read-pkg-up": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^7.0.0"
                     },
                     "dependencies": {
                         "camelcase": {
@@ -17278,9 +17278,9 @@
                             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                             "dev": true,
                             "requires": {
-                                "string-width": "1.0.2",
-                                "strip-ansi": "3.0.1",
-                                "wrap-ansi": "2.1.0"
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wrap-ansi": "^2.0.0"
                             },
                             "dependencies": {
                                 "string-width": {
@@ -17289,9 +17289,9 @@
                                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                                     "dev": true,
                                     "requires": {
-                                        "code-point-at": "1.1.0",
-                                        "is-fullwidth-code-point": "1.0.0",
-                                        "strip-ansi": "3.0.1"
+                                        "code-point-at": "^1.0.0",
+                                        "is-fullwidth-code-point": "^1.0.0",
+                                        "strip-ansi": "^3.0.0"
                                     }
                                 }
                             }
@@ -17304,7 +17304,7 @@
                     "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     },
                     "dependencies": {
                         "camelcase": {
@@ -17323,8 +17323,8 @@
             "integrity": "sha512-Ym9Qm5Sw9oXJYChNJk09I/yaXDaV3UDxsa07wcCvILzIeSJTnSUZjhS4y2YkULzgE8VHOv9X04KtlJPZGwXqMg==",
             "dev": true,
             "requires": {
-                "md5": "2.2.1",
-                "uglify-js": "2.8.29"
+                "md5": "^2.2.1",
+                "uglify-js": "^2.8.29"
             },
             "dependencies": {
                 "camelcase": {
@@ -17339,8 +17339,8 @@
                     "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                     "dev": true,
                     "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                     }
                 },
@@ -17356,9 +17356,9 @@
                     "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
                     }
                 },
                 "yargs": {
@@ -17367,9 +17367,9 @@
                     "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
+                        "camelcase": "^1.0.2",
+                        "cliui": "^2.1.0",
+                        "decamelize": "^1.0.0",
                         "window-size": "0.1.0"
                     }
                 }
@@ -17381,8 +17381,8 @@
             "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
             "dev": true,
             "requires": {
-                "source-list-map": "0.1.8",
-                "source-map": "0.4.4"
+                "source-list-map": "~0.1.7",
+                "source-map": "~0.4.1"
             },
             "dependencies": {
                 "source-list-map": {
@@ -17397,7 +17397,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -17408,11 +17408,11 @@
             "integrity": "sha512-FCrqPy1yy/sN6U/SaEZcHKRXGlqU0DUaEBL45jkUYoB8foVb6wCnbIJ1HKIx+qUFTW+3JpVcCJCxZ8VATL4e+A==",
             "dev": true,
             "requires": {
-                "memory-fs": "0.4.1",
-                "mime": "1.6.0",
-                "path-is-absolute": "1.0.1",
-                "range-parser": "1.2.0",
-                "time-stamp": "2.0.0"
+                "memory-fs": "~0.4.1",
+                "mime": "^1.5.0",
+                "path-is-absolute": "^1.0.0",
+                "range-parser": "^1.0.3",
+                "time-stamp": "^2.0.0"
             }
         },
         "webpack-dev-server": {
@@ -17422,28 +17422,28 @@
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",
-                "bonjour": "3.5.0",
-                "chokidar": "1.7.0",
-                "compression": "1.7.2",
-                "connect-history-api-fallback": "1.5.0",
-                "del": "3.0.0",
-                "express": "4.16.2",
-                "html-entities": "1.2.1",
-                "http-proxy-middleware": "0.17.4",
-                "internal-ip": "1.2.0",
-                "ip": "1.1.5",
-                "loglevel": "1.6.1",
+                "bonjour": "^3.5.0",
+                "chokidar": "^1.6.0",
+                "compression": "^1.5.2",
+                "connect-history-api-fallback": "^1.3.0",
+                "del": "^3.0.0",
+                "express": "^4.13.3",
+                "html-entities": "^1.2.0",
+                "http-proxy-middleware": "~0.17.4",
+                "internal-ip": "^1.2.0",
+                "ip": "^1.1.5",
+                "loglevel": "^1.4.1",
                 "opn": "4.0.2",
-                "portfinder": "1.0.13",
-                "selfsigned": "1.10.2",
-                "serve-index": "1.9.1",
+                "portfinder": "^1.0.9",
+                "selfsigned": "^1.9.1",
+                "serve-index": "^1.7.2",
                 "sockjs": "0.3.18",
                 "sockjs-client": "1.1.4",
-                "spdy": "3.4.7",
-                "strip-ansi": "3.0.1",
-                "supports-color": "3.2.3",
-                "webpack-dev-middleware": "1.12.2",
-                "yargs": "6.6.0"
+                "spdy": "^3.4.1",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^3.1.1",
+                "webpack-dev-middleware": "^1.11.0",
+                "yargs": "^6.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -17464,8 +17464,8 @@
                     "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
                     "dev": true,
                     "requires": {
-                        "object-assign": "4.1.1",
-                        "pinkie-promise": "2.0.1"
+                        "object-assign": "^4.0.1",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -17474,7 +17474,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 },
                 "y18n": {
@@ -17489,19 +17489,19 @@
                     "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "4.2.1"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^4.2.0"
                     }
                 },
                 "yargs-parser": {
@@ -17510,7 +17510,7 @@
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0"
+                        "camelcase": "^3.0.0"
                     }
                 }
             }
@@ -17521,7 +17521,7 @@
             "integrity": "sha512-/0QYwW/H1N/CdXYA2PNPVbsxO3u2Fpz34vs72xm03SRfg6bMNGfMJIQEpQjKRvkG2JvT6oRJFpDtSrwbX8Jzvw==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.5"
+                "lodash": "^4.17.5"
             }
         },
         "webpack-sources": {
@@ -17530,8 +17530,8 @@
             "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
             "dev": true,
             "requires": {
-                "source-list-map": "2.0.0",
-                "source-map": "0.6.1"
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
             }
         },
         "webpack-subresource-integrity": {
@@ -17540,7 +17540,7 @@
             "integrity": "sha1-j6yKfo61n8ahZ2ioXJ2U7n+dDts=",
             "dev": true,
             "requires": {
-                "webpack-core": "0.6.9"
+                "webpack-core": "^0.6.8"
             }
         },
         "websocket-driver": {
@@ -17549,8 +17549,8 @@
             "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
             "dev": true,
             "requires": {
-                "http-parser-js": "0.4.10",
-                "websocket-extensions": "0.1.3"
+                "http-parser-js": ">=0.4.0",
+                "websocket-extensions": ">=0.1.1"
             }
         },
         "websocket-extensions": {
@@ -17577,7 +17577,7 @@
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -17592,7 +17592,7 @@
             "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2"
             }
         },
         "widest-line": {
@@ -17601,7 +17601,7 @@
             "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
             "dev": true,
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -17622,8 +17622,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -17632,7 +17632,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -17649,13 +17649,13 @@
             "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
             "dev": true,
             "requires": {
-                "async": "1.0.0",
-                "colors": "1.0.3",
-                "cycle": "1.0.3",
-                "eyes": "0.1.8",
-                "isstream": "0.1.2",
-                "pkginfo": "0.3.1",
-                "stack-trace": "0.0.10"
+                "async": "~1.0.0",
+                "colors": "1.0.x",
+                "cycle": "1.0.x",
+                "eyes": "0.1.x",
+                "isstream": "0.1.x",
+                "pkginfo": "0.3.x",
+                "stack-trace": "0.0.x"
             },
             "dependencies": {
                 "async": {
@@ -17690,8 +17690,8 @@
             "integrity": "sha512-ITyClEvcfv0ozqJl1vmWFWhvI+OIrkbInYqkEPE50wFPXj8J9Gd3FYf8+CkZJXJJsQBYe+2DvmoK9Zhx5w8W+w==",
             "dev": true,
             "requires": {
-                "errno": "0.1.7",
-                "xtend": "4.0.1"
+                "errno": "~0.1.7",
+                "xtend": "~4.0.1"
             }
         },
         "wrap-ansi": {
@@ -17700,8 +17700,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -17716,9 +17716,9 @@
             "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "signal-exit": "3.0.2"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
             }
         },
         "ws": {
@@ -17727,8 +17727,8 @@
             "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
             "dev": true,
             "requires": {
-                "options": "0.0.6",
-                "ultron": "1.0.2"
+                "options": ">=0.0.5",
+                "ultron": "1.0.x"
             }
         },
         "wtf-8": {
@@ -17773,7 +17773,7 @@
             "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
             "dev": true,
             "requires": {
-                "cuint": "0.2.2"
+                "cuint": "^0.2.2"
             }
         },
         "y18n": {
@@ -17794,19 +17794,19 @@
             "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "5.0.0"
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^5.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -17829,7 +17829,7 @@
             "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0"
+                "camelcase": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -17858,10 +17858,10 @@
             "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
             "dev": true,
             "requires": {
-                "archiver-utils": "1.3.0",
-                "compress-commons": "1.2.2",
-                "lodash": "4.17.5",
-                "readable-stream": "2.3.5"
+                "archiver-utils": "^1.3.0",
+                "compress-commons": "^1.2.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "zone.js": {

--- a/src/clr-angular/data/datagrid/datagrid-cell.ts
+++ b/src/clr-angular/data/datagrid/datagrid-cell.ts
@@ -3,10 +3,23 @@
  * This software is released under MIT license.
  * The full license information can be found in LICENSE in the root directory of this project.
  */
-import {Component, ContentChildren, ElementRef, QueryList, Renderer2} from "@angular/core";
+import {
+    Component,
+    ContentChildren,
+    ElementRef,
+    Injector,
+    OnInit,
+    QueryList,
+    Renderer2,
+    ViewContainerRef
+} from "@angular/core";
 import {Subscription} from "rxjs/Subscription";
+
 import {ClrSignpost} from "../../popover/signpost/signpost";
+import {HostWrapper} from "../../utils/host-wrapping";
+
 import {HideableColumnService} from "./providers/hideable-column.service";
+import {ClrWrappedCell} from "./wrapped-cell";
 
 @Component({
     selector: "clr-dg-cell",
@@ -15,7 +28,7 @@ import {HideableColumnService} from "./providers/hideable-column.service";
     `,
     host: {"[class.datagrid-cell]": "true", "[class.datagrid-signpost-trigger]": "signpost.length > 0"}
 })
-export class ClrDatagridCell {
+export class ClrDatagridCell implements OnInit {
     /*********
      * @property signpost
      *
@@ -43,8 +56,7 @@ export class ClrDatagridCell {
     private hiddenStateSubscription: Subscription;
 
     constructor(public hideableColumnService: HideableColumnService, private _el: ElementRef,
-                private _renderer: Renderer2) {}
-
+                private _renderer: Renderer2, private vcr: ViewContainerRef, el: ElementRef) {}
 
     private mapHideableColumn(columnId: string) {
         if (!columnId) {
@@ -65,6 +77,12 @@ export class ClrDatagridCell {
         } else {
             this._renderer.removeClass(this._el.nativeElement, "datagrid-cell--hidden");
         }
+    }
+
+    private cellInjector: Injector;
+
+    ngOnInit() {
+        this.cellInjector = new HostWrapper(ClrWrappedCell, this.vcr);
     }
 
     ngOnDestroy() {

--- a/src/clr-angular/data/datagrid/datagrid-row.ts
+++ b/src/clr-angular/data/datagrid/datagrid-row.ts
@@ -21,9 +21,11 @@ import {LoadingListener} from "../../utils/loading/loading-listener";
 
 import {ClrDatagridCell} from "./datagrid-cell";
 import {DatagridHideableColumnModel} from "./datagrid-hideable-column.model";
+import {ClrDatagridTemplatesService} from "./providers/datagrid-templates.service";
 import {ExpandableRowsCount} from "./providers/global-expandable-rows";
 import {HideableColumnService} from "./providers/hideable-column.service";
 import {RowActionService} from "./providers/row-action-service";
+import {ClrDatagridRowTemplatesService} from "./providers/row-templates.service";
 import {Selection, SelectionType} from "./providers/selection";
 
 
@@ -82,7 +84,7 @@ let nbRow: number = 0;
         "[class.datagrid-selected]": "selected",
         "[attr.tabindex]": "selection.rowSelectionMode ? 0 : null"
     },
-    providers: [Expand, {provide: LoadingListener, useExisting: Expand}]
+    providers: [Expand, {provide: LoadingListener, useExisting: Expand}, ClrDatagridRowTemplatesService]
 })
 export class ClrDatagridRow implements AfterContentInit {
     public id: string;
@@ -102,7 +104,9 @@ export class ClrDatagridRow implements AfterContentInit {
 
     constructor(public selection: Selection, public rowActionService: RowActionService,
                 public globalExpandable: ExpandableRowsCount, public expand: Expand,
-                public hideableColumnService: HideableColumnService) {
+                public hideableColumnService: HideableColumnService,
+                private rowTemplateService: ClrDatagridRowTemplatesService,
+                private datagridTemplatesServices: ClrDatagridTemplatesService) {
         this.id = "clr-dg-row" + (nbRow++);
         this.role = selection.rowSelectionMode ? "button" : null;
     }
@@ -222,6 +226,9 @@ export class ClrDatagridRow implements AfterContentInit {
         });
     }
 
+    ngAfterViewInit() {
+        this.datagridTemplatesServices.addTemplateService(this.rowTemplateService.cells);
+    }
     /**********
      *
      * @description

--- a/src/clr-angular/data/datagrid/datagrid.html
+++ b/src/clr-angular/data/datagrid/datagrid.html
@@ -4,47 +4,76 @@
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
-<ng-content select="clr-dg-action-bar"></ng-content>
-<div class="datagrid" #datagrid>
-    <clr-dg-table-wrapper class="datagrid-table">
-        <div clrDgHead class="datagrid-header">
-            <div class="datagrid-row datagrid-row-flex">
-                <!-- header for datagrid where you can select multiple rows -->
-                <div class="datagrid-column datagrid-select datagrid-fixed-column"
-                     *ngIf="selection.selectionType === SELECTION_TYPE.Multi">
+<ng-container *ngIf="display">
+    <h1>TemplateRef Table</h1>
+    <ng-content select="clr-dg-action-bar"></ng-content>
+
+    <div class="datagrid">
+        <clr-dg-table-wrapper class="datagrid-table">
+            <div clrDgHead class="datagrid-header">
+                <div class="datagrid-row datagrid-row-flex">
+                    <!-- header for datagrid where you can select multiple rows -->
+                    <div class="datagrid-column datagrid-select datagrid-fixed-column"
+                         *ngIf="selection.selectionType === SELECTION_TYPE.Multi">
                         <span class="datagrid-column-title">
                             <clr-checkbox [(ngModel)]="allSelected"></clr-checkbox>
                         </span>
-                    <div class="datagrid-column-separator"></div>
+                        <div class="datagrid-column-separator"></div>
+                    </div>
+                    <!-- header for datagrid where you can select one row only -->
+                    <div class="datagrid-column datagrid-select datagrid-fixed-column"
+                         *ngIf="selection.selectionType === SELECTION_TYPE.Single">
+                        <div class="datagrid-column-separator"></div>
+                    </div>
+                    <!-- header for single row action; only display if we have at least one actionable row in datagrid -->
+                    <div class="datagrid-column datagrid-row-actions datagrid-fixed-column"
+                         *ngIf="rowActionService.hasActionableRow">
+                        <div class="datagrid-column-separator"></div>
+                    </div>
+                    <!-- header for carets; only display if we have at least one expandable row in datagrid -->
+                    <div class="datagrid-column datagrid-expandable-caret datagrid-fixed-column"
+                         *ngIf="expandableRows.hasExpandableRow">
+                        <div class="datagrid-column-separator"></div>
+                    </div>
+                    <!--<ng-content select="clr-dg-column"></ng-content>-->
+                    <span>column template refs here</span>
                 </div>
-                <!-- header for datagrid where you can select one row only -->
-                <div class="datagrid-column datagrid-select datagrid-fixed-column"
-                     *ngIf="selection.selectionType === SELECTION_TYPE.Single">
-                    <div class="datagrid-column-separator"></div>
-                </div>
-                <!-- header for single row action; only display if we have at least one actionable row in datagrid -->
-                <div class="datagrid-column datagrid-row-actions datagrid-fixed-column"
-                     *ngIf="rowActionService.hasActionableRow">
-                    <div class="datagrid-column-separator"></div>
-                </div>
-                <!-- header for carets; only display if we have at least one expandable row in datagrid -->
-                <div class="datagrid-column datagrid-expandable-caret datagrid-fixed-column"
-                     *ngIf="expandableRows.hasExpandableRow">
-                    <div class="datagrid-column-separator"></div>
-                </div>
-                <ng-content select="clr-dg-column"></ng-content>
             </div>
-        </div>
-        <ng-template *ngIf="iterator"
-                     ngFor [ngForOf]="items.displayed" [ngForTrackBy]="items.trackBy"
-                     [ngForTemplate]="iterator.template"></ng-template>
-        <ng-content *ngIf="!iterator"></ng-content>
-        <!-- Custom placeholder overrides the default empty one -->
-        <ng-content select="clr-dg-placeholder"></ng-content>
-        <clr-dg-placeholder *ngIf="!placeholder"></clr-dg-placeholder>
-    </clr-dg-table-wrapper>
-</div>
-<ng-content select="clr-dg-footer"></ng-content>
-<div class="datagrid-spinner" *ngIf="loading">
-    <div class="spinner">Loading...</div>
-</div>
+            <span>*ngFor and *clrDgItems iterator go here</span>
+            <!--<ng-template *ngIf="iterator"-->
+                         <!--ngFor [ngForOf]="items.displayed" [ngForTrackBy]="items.trackBy"-->
+                         <!--[ngForTemplate]="iterator.template"></ng-template>-->
+            <!--<ng-content *ngIf="!iterator"></ng-content>-->
+            <!-- Custom placeholder overrides the default empty one -->
+            <ng-container *ngIf="iterator">
+                TODO: handle iterator rows/cells
+            </ng-container>
+
+            <ng-container *ngIf="!iterator">
+                <ng-container *ngFor="let row of rowTemplateArrays">
+                    <ng-content></ng-content>
+                </ng-container>
+            </ng-container>
+            <ng-content select="clr-dg-placeholder"></ng-content>
+            <clr-dg-placeholder *ngIf="!placeholder"></clr-dg-placeholder>
+        </clr-dg-table-wrapper>
+    </div>
+
+    <ng-content select="clr-dg-footer"></ng-content>
+    <div class="datagrid-spinner" *ngIf="loading">
+        <div class="spinner">Loading...</div>
+    </div>
+</ng-container>
+<h4>{{display ? 'Standard display' : 'calculation'}} table</h4>
+
+<ng-container *ngIf="!display">
+    <h1>Calculation View</h1>
+    <div class="datagrid-sizing datagrid-table">
+        <ng-container>
+            <div *ngFor="let row of rowTemplateArrays" class="datagrid-row datagrid-row-flex">
+                <ng-container *ngFor="let cell of row" [ngTemplateOutlet]="cell"></ng-container>
+            </div>
+        </ng-container>
+    </div>
+</ng-container>
+<button class="btn btn-primary" (click)="display = !display">Switch Table View</button>

--- a/src/clr-angular/data/datagrid/datagrid.html
+++ b/src/clr-angular/data/datagrid/datagrid.html
@@ -39,19 +39,21 @@
                     <span>column template refs here</span>
                 </div>
             </div>
-            <span>*ngFor and *clrDgItems iterator go here</span>
             <!--<ng-template *ngIf="iterator"-->
-                         <!--ngFor [ngForOf]="items.displayed" [ngForTrackBy]="items.trackBy"-->
-                         <!--[ngForTemplate]="iterator.template"></ng-template>-->
+            <!--ngFor [ngForOf]="items.displayed" [ngForTrackBy]="items.trackBy"-->
+            <!--[ngForTemplate]="iterator.template"></ng-template>-->
             <!--<ng-content *ngIf="!iterator"></ng-content>-->
-            <!-- Custom placeholder overrides the default empty one -->
             <ng-container *ngIf="iterator">
-                TODO: handle iterator rows/cells
+                handle clrDgItems
             </ng-container>
 
             <ng-container *ngIf="!iterator">
                 <ng-container *ngFor="let row of rowTemplateArrays">
-                    <ng-content></ng-content>
+                    <div class="datagrid-row datagrid-row-flex">
+                        <ng-template ngFor [ngForOf]="row" let-cell>
+                            <ng-container [ngTemplateOutlet]="cell"></ng-container>
+                        </ng-template>
+                    </div>
                 </ng-container>
             </ng-container>
             <ng-content select="clr-dg-placeholder"></ng-content>

--- a/src/clr-angular/data/datagrid/datagrid.module.ts
+++ b/src/clr-angular/data/datagrid/datagrid.module.ts
@@ -50,13 +50,14 @@ import {DatagridHeaderRenderer} from "./render/header-renderer";
 import {DatagridMainRenderer} from "./render/main-renderer";
 import {DatagridRowRenderer} from "./render/row-renderer";
 import {DatagridTableRenderer} from "./render/table-renderer";
+import {ClrWrappedCell} from "./wrapped-cell";
 
 export const CLR_DATAGRID_DIRECTIVES: Type<any>[] = [
     // Core
     ClrDatagrid, ClrDatagridActionBar, ClrDatagridActionOverflow, ClrDatagridColumn, ClrDatagridColumnToggle,
     ClrDatagridHideableColumn, ClrDatagridFilter, ClrDatagridItems, ClrDatagridItemsTrackBy, ClrDatagridRow,
     ClrDatagridRowDetail, DatagridDetailRegisterer, ClrDatagridCell, ClrDatagridFooter, ClrDatagridPagination,
-    ClrDatagridPlaceholder, ClrDatagridColumnToggleButton, ClrDatagridColumnToggleTitle,
+    ClrDatagridPlaceholder, ClrDatagridColumnToggleButton, ClrDatagridColumnToggleTitle, ClrWrappedCell,
 
     // Renderers
     DatagridMainRenderer, DatagridTableRenderer, DatagridHeadRenderer, DatagridHeaderRenderer, DatagridBodyRenderer,
@@ -80,7 +81,8 @@ export const CLR_DATAGRID_DIRECTIVES: Type<any>[] = [
     declarations: [
         CLR_DATAGRID_DIRECTIVES,
     ],
-    exports: [CLR_DATAGRID_DIRECTIVES, ClrIfExpandModule]
+    exports: [CLR_DATAGRID_DIRECTIVES, ClrIfExpandModule],
+    entryComponents: [ClrWrappedCell]
 })
 export class ClrDatagridModule {}
 

--- a/src/clr-angular/data/datagrid/datagrid.ts
+++ b/src/clr-angular/data/datagrid/datagrid.ts
@@ -227,6 +227,7 @@ export class ClrDatagrid implements AfterContentInit, AfterViewInit, OnDestroy {
             }
         }));
         this.rowTemplateArrays = this.dataridTemplatesService.rowTemplates;
+        console.log(this.rowTemplateArrays);
     }
 
     public display = true;

--- a/src/clr-angular/data/datagrid/providers/datagrid-templates.service.ts
+++ b/src/clr-angular/data/datagrid/providers/datagrid-templates.service.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {Injectable, TemplateRef} from "@angular/core";
+
+import {ClrDatagridCell} from "../datagrid-cell";
+
+@Injectable()
+export class ClrDatagridTemplatesService {
+    private templatesServices: TemplateRef<void>[][] =
+        [];  // collection of rowTemplates needs to be observable? prolly b/c what happens when we add new rows and
+             // remove old ones?
+
+    // let somone get the array of cells for this row.
+    public get rowTemplates(): TemplateRef<void>[][] {
+        return this.templatesServices;
+    }
+
+    // Let something (a cell) add a template to the collection of rowTemplates
+    public addTemplateService(service: TemplateRef<void>[]): void {
+        this.templatesServices.push(service);
+    }
+}

--- a/src/clr-angular/data/datagrid/providers/row-templates.service.ts
+++ b/src/clr-angular/data/datagrid/providers/row-templates.service.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import {Injectable, TemplateRef} from "@angular/core";
+
+@Injectable()
+export class ClrDatagridRowTemplatesService {
+    // TODO - type the arrays properly
+    private templates: TemplateRef<void>[] = [];  // collection of rowTemplates QueryList preserves the index/order
+
+    // let somone get the array of cells for this row.
+    // TODO - type the arrays properly
+    public get cells(): TemplateRef<void>[] {
+        return this.templates;
+    }
+
+    // Let something (a cell) add a template to the collection of rowTemplates
+    // TODO - type the arrays properly
+    public addTemplate(template: TemplateRef<void>): void {
+        this.templates.push(template);
+    }
+}

--- a/src/clr-angular/data/datagrid/wrapped-cell.ts
+++ b/src/clr-angular/data/datagrid/wrapped-cell.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2016-2018 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+import {AfterViewInit, Component, TemplateRef, ViewChild} from "@angular/core";
+
+import {DynamicWrapper} from "../../utils/host-wrapping/dynamic-wrapper";
+import {ClrDatagridRowTemplatesService} from "./providers/row-templates.service";
+
+@Component({
+    selector: "clr-wrapped-cell",
+    template: `        
+        <ng-template #cellPortal>
+            <ng-content></ng-content>
+        </ng-template>
+    `,
+})
+export class ClrWrappedCell implements DynamicWrapper, AfterViewInit {
+    _dynamic = false;
+    @ViewChild("cellPortal") templateRef: TemplateRef<any>;
+
+    constructor(private rowTemplatesService: ClrDatagridRowTemplatesService) {}
+
+    ngAfterViewInit() {
+        this.rowTemplatesService.addTemplate(this.templateRef);
+    }
+}

--- a/src/clr-angular/utils/host-wrapping/host-wrapper.ts
+++ b/src/clr-angular/utils/host-wrapping/host-wrapper.ts
@@ -17,6 +17,15 @@ import {
 import {DynamicWrapper} from "./dynamic-wrapper";
 import {EmptyAnchor} from "./empty-anchor";
 
+
+/**
+ * @class HostWrapper
+ *
+ * @description
+ * HostWrapper must be called in OnInit to ensure that the Views are ready. If its called in a constructor the view is
+ * still undefined.
+ * TODO - make sure these comment annotations do not break ng-packgr.
+ */
 export class HostWrapper<W extends DynamicWrapper> implements Injector {
     constructor(containerType: Type<W>, vcr: ViewContainerRef) {
         this.injector = vcr.injector;


### PR DESCRIPTION
## Projection Code
For now, I'm trying to project the rows of cells (from the service that populates `rowTemplateArrays`) [here](https://github.com/hippee-lee/clarity/pull/2/files#diff-095b21f8867bd5f2cfb045cb1902bee7R52)

```
<ng-container *ngIf="!iterator">
    <ng-container *ngFor="let row of rowTemplateArrays">
        <ng-content></ng-content>
    </ng-container>
</ng-container>
```

## Image of DOM Structure thats rendered for reference

![screen shot 2018-05-24 at 2 39 36 pm](https://user-images.githubusercontent.com/433692/40515114-6bfdc892-5f60-11e8-9ba6-9d337d98e940.png)

I'm getting something wrong with the cell wrapper because its rendering as a sibling of the clr-dg-cell component and I don't think it should be there. 

Signed-off-by: Matt Hippely <mhippely@vmware.com>